### PR TITLE
Improve feedback when applying the configuration

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -89,9 +89,10 @@ p {
         padding-right: var(--pf-global--spacer--xs);
     }
 
-    tr .warning-column {
+    tr .status-column {
         color: var(--pf-global--warning-color--200);
         padding: 0;
-        width: var(--pf-global--spacer--md);
+        width: var(--pf-global--spacer--lg);
+        text-align: center;
     }
 }

--- a/src/components/DeleteConnection.js
+++ b/src/components/DeleteConnection.js
@@ -31,7 +31,7 @@ const DeleteConnection = ({ connection, deleteConnection }) => {
 
     const onClose = () => setConfirmationOpen(false);
 
-    const removeConnectionConfig = () => {
+    const deleteConnectionConfig = () => {
         deleteConnection(connection);
         onClose();
     };
@@ -44,7 +44,7 @@ const DeleteConnection = ({ connection, deleteConnection }) => {
                     title={cockpit.format(_("Delete '$0' configuration"), connection?.name)}
                     isOpen={isConfirmationOpen}
                     onCancel={onClose}
-                    onConfirm={removeConnectionConfig}
+                    onConfirm={deleteConnectionConfig}
                 >
                     {_("Please, confirm that you really want to the delete the interface configuration.")}
                 </ModalConfirm>}

--- a/src/components/InterfaceDetails.js
+++ b/src/components/InterfaceDetails.js
@@ -111,7 +111,7 @@ const renderError = (error) => {
     return <Alert variant="warning" isInline title={error} />;
 };
 
-const InterfaceDetails = ({ iface, connection, changeConnectionState, removeConnection }) => {
+const InterfaceDetails = ({ iface, connection, changeConnectionState, deleteConnection }) => {
     const renderFullDetails = () => {
         if (connection.exists) {
             return (
@@ -134,7 +134,7 @@ const InterfaceDetails = ({ iface, connection, changeConnectionState, removeConn
             <Toolbar>
                 <ToolbarContent>
                     <ToolbarItem>
-                        <DeleteConnection connection={connection} deleteConnection={removeConnection} />
+                        <DeleteConnection connection={connection} deleteConnection={deleteConnection} />
                     </ToolbarItem>
 
                     {

--- a/src/components/InterfacesList.js
+++ b/src/components/InterfacesList.js
@@ -22,13 +22,21 @@
 import cockpit from "cockpit";
 import React, { useState, useEffect, useCallback } from 'react';
 import { Card, CardHeader, CardTitle, CardBody, Spinner } from '@patternfly/react-core';
-import { Table, TableHeader, TableBody, TableVariant, expandable } from '@patternfly/react-table';
+import {
+    Table,
+    TableBody,
+    TableHeader,
+    TableVariant,
+    cellWidth,
+    expandable,
+    truncate
+} from '@patternfly/react-table';
+import AlertIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import InterfaceDetails from "./InterfaceDetails";
 import interfaceType from '../lib/model/interfaceType';
 import interfaceStatus from '../lib/model/interfaceStatus';
 import { useNetworkDispatch, deleteConnection, changeConnectionState } from '../context/network';
 import { createConnection } from '../lib/model/connections';
-import AlertIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 
 const _ = cockpit.gettext;
 
@@ -41,7 +49,7 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
         { title: "", props: { className: "status-column" } },
         { title: _("Name"), cellFormatters: [expandable] },
         { title: _("Type") },
-        { title: _("Status") },
+        { title: _("Status"), transforms: [cellWidth(10)], cellTransforms: [truncate] },
         { title: _("Addresses") }
     ];
 

--- a/src/components/InterfacesList.js
+++ b/src/components/InterfacesList.js
@@ -44,7 +44,7 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
         { title: _("Addresses") }
     ];
 
-    const removeConnection = useCallback((connection) => {
+    const onDeleteConnection = useCallback((connection) => {
         deleteConnection(dispatch, connection);
     }, [dispatch]);
 
@@ -108,7 +108,7 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
                     cells: [
                         "",
                         {
-                            title: <InterfaceDetails iface={i} connection={conn} removeConnection={removeConnection} changeConnectionState={changeState} />,
+                            title: <InterfaceDetails iface={i} connection={conn} deleteConnection={onDeleteConnection} changeConnectionState={changeState} />,
                             props: { colSpan: 4 }
                         }
                     ]
@@ -119,7 +119,7 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
 
             return list;
         }, []);
-    }, [interfaces, openRows, removeConnection, changeState, findOrCreateConnection]);
+    }, [interfaces, openRows, onDeleteConnection, changeState, findOrCreateConnection]);
 
     /**
      * Keeps the openRows internal state up to date using the information provided by the

--- a/src/components/InterfacesList.js
+++ b/src/components/InterfacesList.js
@@ -58,7 +58,7 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
         return iface.addresses.map(i => i.local).join(', ');
     };
 
-    const renderStatusIcon = (iface, conn) => {
+    const renderStatusIcon = (iface) => {
         if (iface.error) {
             return <><AlertIcon /></>;
         } else if (iface.pending) {

--- a/src/components/InterfacesList.js
+++ b/src/components/InterfacesList.js
@@ -25,6 +25,7 @@ import { Card, CardHeader, CardTitle, CardBody, Spinner } from '@patternfly/reac
 import { Table, TableHeader, TableBody, TableVariant, expandable } from '@patternfly/react-table';
 import InterfaceDetails from "./InterfaceDetails";
 import interfaceType from '../lib/model/interfaceType';
+import interfaceStatus from '../lib/model/interfaceStatus';
 import { useNetworkDispatch, deleteConnection, changeConnectionState } from '../context/network';
 import { createConnection } from '../lib/model/connections';
 import AlertIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
@@ -59,10 +60,22 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
     };
 
     const renderStatusIcon = (iface) => {
+        if (!iface.status) return;
+
         if (iface.error) {
             return <><AlertIcon /></>;
-        } else if (iface.pending) {
+        } else if (iface.status !== 'ready') {
             return <><Spinner size="md" /></>;
+        }
+    };
+
+    const renderStatusText = (iface) => {
+        const linkText = iface.link ? _('Up') : _('Down');
+
+        if (!iface.status || iface.status === interfaceStatus.READY) {
+            return linkText;
+        } else {
+            return interfaceStatus.label(iface.status);
         }
     };
 
@@ -94,10 +107,10 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
                 {
                     isOpen: openRows.includes(parentId),
                     cells: [
-                        renderStatusIcon(i, conn),
+                        renderStatusIcon(i),
                         i.name,
                         interfaceType.label(i.type),
-                        i.link ? _('Up') : _('Down'),
+                        renderStatusText(i),
                         interfaceAddresses(i)
                     ]
                 }

--- a/src/components/InterfacesList.js
+++ b/src/components/InterfacesList.js
@@ -59,7 +59,6 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
     };
 
     const renderStatusIcon = (iface, conn) => {
-        console.log("IFACE; pending", iface.pending, "error", iface.error);
         if (iface.error) {
             return <><AlertIcon /></>;
         } else if (iface.pending) {

--- a/src/components/InterfacesList.js
+++ b/src/components/InterfacesList.js
@@ -21,7 +21,7 @@
 
 import cockpit from "cockpit";
 import React, { useState, useEffect, useCallback } from 'react';
-import { Card, CardHeader, CardTitle, CardBody } from '@patternfly/react-core';
+import { Card, CardHeader, CardTitle, CardBody, Spinner } from '@patternfly/react-core';
 import { Table, TableHeader, TableBody, TableVariant, expandable } from '@patternfly/react-table';
 import InterfaceDetails from "./InterfaceDetails";
 import interfaceType from '../lib/model/interfaceType';
@@ -37,7 +37,7 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
     const dispatch = useNetworkDispatch();
 
     const columns = [
-        { title: "", props: { className: "warning-column" } },
+        { title: "", props: { className: "status-column" } },
         { title: _("Name"), cellFormatters: [expandable] },
         { title: _("Type") },
         { title: _("Status") },
@@ -58,10 +58,13 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
         return iface.addresses.map(i => i.local).join(', ');
     };
 
-    const renderAlertIcon = (iface) => {
-        if (!iface.error) return;
-
-        return <><AlertIcon /></>;
+    const renderStatusIcon = (iface, conn) => {
+        console.log("IFACE; pending", iface.pending, "error", iface.error);
+        if (iface.error) {
+            return <><AlertIcon /></>;
+        } else if (iface.pending) {
+            return <><Spinner size="md" /></>;
+        }
     };
 
     /**
@@ -92,7 +95,7 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
                 {
                     isOpen: openRows.includes(parentId),
                     cells: [
-                        renderAlertIcon(i),
+                        renderStatusIcon(i, conn),
                         i.name,
                         interfaceType.label(i.type),
                         i.link ? _('Up') : _('Down'),

--- a/src/components/InterfacesList.js
+++ b/src/components/InterfacesList.js
@@ -64,7 +64,7 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
 
         if (iface.error) {
             return <><AlertIcon /></>;
-        } else if (iface.status !== 'ready') {
+        } else if (iface.status !== interfaceStatus.READY) {
             return <><Spinner size="md" /></>;
         }
     };

--- a/src/context/network.js
+++ b/src/context/network.js
@@ -163,7 +163,7 @@ function networkReducer(state, action) {
         const iface = Object.values(interfaces).find(i => i.name === name);
         return {
             ...state,
-            interfaces: { ...interfaces, [iface.id]: { ...iface, error: message, status: 'error' } }
+            interfaces: { ...interfaces, [iface.id]: { ...iface, error: message, status: interfaceStatus.ERROR } }
         };
     }
 

--- a/src/context/network.js
+++ b/src/context/network.js
@@ -51,7 +51,9 @@ const actionTypes = {
     ADD_CONNECTION,
     DELETE_CONNECTION,
     UPDATE_CONNECTION,
-    UPDATE_INTERFACE
+    UPDATE_INTERFACE,
+    CONNECTION_CHANGE_REQUEST,
+    CONNECTION_ERROR
 };
 
 function networkReducer(state, action) {
@@ -249,6 +251,7 @@ async function addConnection(dispatch, attrs) {
     } catch (error) {
         dispatch({ type: CONNECTION_ERROR, payload: { error, connection: addedConn } });
     }
+
     return addedConn;
 }
 

--- a/src/context/network.js
+++ b/src/context/network.js
@@ -344,13 +344,12 @@ function addRoute(dispatch, routes, attrs) {
  *
  * @return {Promise.<boolean>} Promise that resolves to true if service is active or false if not
  */
-function serviceIsActive() {
-    return networkClient().isActive()
-            .then(result => result)
-            .catch((error) => {
-                console.error(error);
-                return false;
-            });
+async function serviceIsActive() {
+    try {
+        return await networkClient().isActive();
+    } catch (error) {
+        return false;
+    }
 }
 
 /**

--- a/src/context/network.js
+++ b/src/context/network.js
@@ -151,7 +151,9 @@ function networkReducer(state, action) {
         return {
             ...state,
             interfaces: {
-                ...interfaces, [oldIface.id]: { ...oldIface, ...action.payload, id: oldIface.id }
+                ...interfaces, [oldIface.id]: {
+                    ...oldIface, ...action.payload, id: oldIface.id, pending: false, error: false
+                }
             }
         };
     }
@@ -164,7 +166,7 @@ function networkReducer(state, action) {
 
         return {
             ...state,
-            interfaces: { ...interfaces, [iface.id]: { ...iface, pending: true } }
+            interfaces: { ...interfaces, [iface.id]: { ...iface, error: false, pending: true } }
         };
     }
 
@@ -174,7 +176,7 @@ function networkReducer(state, action) {
         const iface = Object.values(interfaces).find(i => i.name === name);
         return {
             ...state,
-            interfaces: { ...interfaces, [iface.id]: { ...iface, error: message } }
+            interfaces: { ...interfaces, [iface.id]: { ...iface, error: message, pending: false } }
         };
     }
 

--- a/src/context/network.js
+++ b/src/context/network.js
@@ -250,8 +250,6 @@ async function addConnection(dispatch, attrs) {
  *
  * If the update was successful, it dispatches the UPDATE_CONNECTION action.
  *
- * @todo Notify when something went wrong.
- *
  * @param {function} dispatch - Dispatch function
  * @param {Connection} connection - Connection to update
  * @param {Object|Connection} changes - Changes to apply to the connection
@@ -272,6 +270,13 @@ async function updateConnection(dispatch, connection, changes) {
     return updatedConn;
 }
 
+/**
+ * Deletes a coonnection using the NetworkClient
+ *
+ * @param {function} dispatch - Dispatch function
+ * @param {Connection} connection - Connection to delete
+ * @return {Promise}
+ */
 async function deleteConnection(dispatch, connection) {
     dispatch({ type: UPDATE_INTERFACE, payload: { name: connection.name, status: interfaceStatus.CONFIGURING } });
 
@@ -285,6 +290,14 @@ async function deleteConnection(dispatch, connection) {
     }
 }
 
+/**
+ * Activate/Deactivate a connection
+ *
+ * @param {function} dispatch - Dispatch function
+ * @param {Connection} connection - Connection to activate/deactivate
+ * @param {Boolean} setUp - Whether the connection should be activated (true) or deactivated (false)
+ * @return {Promise}
+ */
 async function changeConnectionState(dispatch, connection, setUp) {
     dispatch({ type: UPDATE_INTERFACE, payload: { name: connection.name, status: interfaceStatus.IN_PROGRESS } });
 
@@ -384,6 +397,12 @@ function fetchRoutes(dispatch) {
             .catch(console.error);
 }
 
+/**
+ * Fetches the list of wireless ESSIDs
+ *
+ * @param {string} name - Interface name
+ * @return {Promise.<string[]>} List of ESSIDs.
+ */
 function fetchEssidList(name) {
     return networkClient().getEssidList(name);
 }

--- a/src/context/network.js
+++ b/src/context/network.js
@@ -285,7 +285,7 @@ async function deleteConnection(dispatch, connection) {
     dispatch({ type: CONNECTION_CHANGE_REQUEST, payload: { name: connection.name } });
 
     try {
-        await networkClient().removeConnection(connection);
+        await networkClient().deleteConnection(connection);
         dispatch({ type: DELETE_CONNECTION, payload: connection });
         await networkClient().setDownConnection(connection);
     } catch (error) {

--- a/src/context/network.test.js
+++ b/src/context/network.test.js
@@ -20,65 +20,145 @@
  */
 
 import { addConnection, updateConnection, actionTypes, resetClient } from './network';
-import model from '../lib/model';
 import interfaceType from '../lib/model/interfaceType';
 import NetworkClient from '../lib/NetworkClient';
 
 jest.mock('../lib/NetworkClient');
 
 describe('#addConnection', () => {
+    const addConnectionMock = jest.fn(conn => Promise.resolve(conn));
+    const reloadConnectionMock = jest.fn(name => Promise.resolve());
+
     beforeAll(() => {
         resetClient();
         NetworkClient.mockImplementation(() => {
             return {
-                addConnection: (conn) => Promise.resolve(conn),
-                reloadConnection: (name) => Promise.resolve()
+                addConnection: addConnectionMock,
+                reloadConnection: reloadConnectionMock
             };
         });
     });
 
-    it('asks the network client to add the connection', () => {
+    afterAll(() => {
+        addConnectionMock.mockClear();
+        reloadConnectionMock.mockClear();
+    });
+
+    it('asks the network client to add the connection', async () => {
         const dispatchFn = jest.fn();
 
-        expect.assertions(1);
-        return addConnection(dispatchFn, { name: 'eth0', type: interfaceType.BRIDGE })
-                .then(result => {
-                    expect(result).toEqual(expect.objectContaining({ name: 'eth0' }));
-                });
+        const addedConn = await addConnection(
+            dispatchFn, { name: 'eth0', type: interfaceType.BRIDGE }
+        );
+
+        expect(addedConn).toEqual(expect.objectContaining({ name: 'eth0' }));
+        expect(addConnectionMock).toHaveBeenCalledWith(
+            expect.objectContaining({ name: 'eth0' })
+        );
+        expect(reloadConnectionMock).toHaveBeenCalledWith('eth0');
+    });
+
+    it('dispatches an ADD_CONNECTION action', async () => {
+        const dispatchFn = jest.fn();
+
+        await addConnection(dispatchFn, { name: 'eth0', type: interfaceType.BRIDGE });
+
+        expect(dispatchFn).toHaveBeenCalledWith(
+            expect.objectContaining(
+                {
+                    type: actionTypes.ADD_CONNECTION,
+                    payload: expect.objectContaining({ name: 'eth0' })
+                }
+            )
+        );
+    });
+
+    it('dispatches a CONNECTION_ERROR if something went wrong', async () => {
+        const dispatchFn = jest.fn();
+        const error = new Error({ message: 'something went wrong' });
+        addConnectionMock.mockImplementation((conn) => { throw error });
+
+        await addConnection(dispatchFn, { name: 'eth0', type: interfaceType.BRIDGE });
+
+        expect(dispatchFn).toHaveBeenCalledWith(
+            expect.objectContaining(
+                {
+                    type: actionTypes.CONNECTION_ERROR,
+                    payload: expect.objectContaining({
+                        error,
+                        connection: expect.objectContaining({ name: 'eth0' })
+                    })
+                }
+            )
+        );
     });
 });
 
 describe('#updateConnection', () => {
+    const updateConnectionMock = jest.fn(conn => Promise.resolve(conn));
+    const reloadConnectionMock = jest.fn(name => Promise.resolve());
+
     beforeAll(() => {
         resetClient();
         NetworkClient.mockImplementation(() => {
             return {
-                updateConnection: (conn) => Promise.resolve(conn),
-                reloadConnection: (name) => Promise.resolve(),
+                updateConnection: updateConnectionMock,
+                reloadConnection: reloadConnectionMock
             };
         });
     });
 
-    it('asks the network client to update the connection', () => {
-        const dispatchFn = jest.fn();
-        const conn = model.createConnection({ name: 'eth0' });
-
-        expect.assertions(1);
-        return updateConnection(dispatchFn, conn, { name: 'eth1' })
-                .then(result => {
-                    expect(result).toEqual(expect.objectContaining({ name: 'eth1' }));
-                });
+    afterAll(() => {
+        updateConnectionMock.mockClear();
+        reloadConnectionMock.mockClear();
     });
 
-    it('dispatches a UPDATE_CONNECTION action', () => {
+    it('asks the network client to update the connection', async () => {
         const dispatchFn = jest.fn();
-        const conn = model.createConnection({ name: 'eth0' });
 
-        return updateConnection(dispatchFn, conn, { name: 'eth1' })
-                .then(result => {
-                    expect(dispatchFn).toHaveBeenCalledWith(
-                        expect.objectContaining({ type: actionTypes.UPDATE_CONNECTION })
-                    );
-                });
+        const updatedConn = await updateConnection(
+            dispatchFn, { name: 'eth1' }
+        );
+
+        expect(updatedConn).toEqual(expect.objectContaining({ name: 'eth1' }));
+        expect(updateConnectionMock).toHaveBeenCalledWith(
+            expect.objectContaining({ name: 'eth1' })
+        );
+        expect(reloadConnectionMock).toHaveBeenCalledWith('eth1');
+    });
+
+    it('dispatches an UPDATE_CONNECTION action', async () => {
+        const dispatchFn = jest.fn();
+
+        await updateConnection(dispatchFn, { name: 'eth1' });
+
+        expect(dispatchFn).toHaveBeenCalledWith(
+            expect.objectContaining(
+                {
+                    type: actionTypes.UPDATE_CONNECTION,
+                    payload: expect.objectContaining({ name: 'eth1' })
+                }
+            )
+        );
+    });
+
+    it('dispatches a CONNECTION_ERROR if something went wrong', async () => {
+        const dispatchFn = jest.fn();
+        const error = new Error({ message: 'something went wrong' });
+        updateConnectionMock.mockImplementation((conn) => { throw error });
+
+        await updateConnection(dispatchFn, { name: 'eth0', type: interfaceType.BRIDGE });
+
+        expect(dispatchFn).toHaveBeenCalledWith(
+            expect.objectContaining(
+                {
+                    type: actionTypes.CONNECTION_ERROR,
+                    payload: expect.objectContaining({
+                        error,
+                        connection: expect.objectContaining({ name: 'eth0' })
+                    })
+                }
+            )
+        );
     });
 });

--- a/src/context/network.test.js
+++ b/src/context/network.test.js
@@ -27,6 +27,7 @@ import {
     resetClient
 } from './network';
 import interfaceType from '../lib/model/interfaceType';
+import interfaceStatus from '../lib/model/interfaceStatus';
 import NetworkClient from '../lib/NetworkClient';
 
 jest.mock('../lib/NetworkClient');
@@ -74,6 +75,29 @@ describe('#addConnection', () => {
                 {
                     type: actionTypes.ADD_CONNECTION,
                     payload: expect.objectContaining({ name: 'eth0' })
+                }
+            )
+        );
+    });
+
+    it('updates the interface status', async () => {
+        const dispatchFn = jest.fn();
+
+        await addConnection(dispatchFn, { name: 'eth0', type: interfaceType.BRIDGE });
+        expect(dispatchFn).toHaveBeenCalledWith(
+            expect.objectContaining(
+                {
+                    type: actionTypes.UPDATE_INTERFACE,
+                    payload: expect.objectContaining({ name: 'eth0', status: interfaceStatus.CONFIGURING })
+                }
+            )
+        );
+
+        expect(dispatchFn).toHaveBeenCalledWith(
+            expect.objectContaining(
+                {
+                    type: actionTypes.UPDATE_INTERFACE,
+                    payload: expect.objectContaining({ name: 'eth0', status: interfaceStatus.READY })
                 }
             )
         );

--- a/src/lib/NetworkClient.js
+++ b/src/lib/NetworkClient.js
@@ -92,8 +92,8 @@ class NetworkClient {
         return this.adapter.addConnection(connection);
     }
 
-    removeConnection(connection) {
-        return this.adapter.removeConnection(connection);
+    deleteConnection(connection) {
+        return this.adapter.deleteConnection(connection);
     }
 
     /**

--- a/src/lib/model/interfaceStatus.js
+++ b/src/lib/model/interfaceStatus.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) [2020] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import cockpit from 'cockpit';
+
+const _ = cockpit.gettext;
+const NC_ = cockpit.noop;
+
+/**
+ * This enum indicates the status interface within the workflow.
+ *
+ * - CONFIGURING: the configuration is being updated (writing files and so on).
+ * - IN_PROGRESS: the interface is changing its status (according to the configuration or on demand).
+ * - READY: the interface has been configured with no error.
+ * - ERROR: the interface could not be configured accoding to the configuration.
+ */
+const CONFIGURING = 'configuring';
+const IN_PROGRESS = 'in_progress';
+const READY = 'ready';
+const ERROR = 'error';
+
+const labels = {
+    [CONFIGURING]: NC_('Configuring'),
+    [IN_PROGRESS]: NC_('Set-up in progress'),
+    [READY]: NC_('Ready'),
+    [ERROR]: NC_('Error'),
+};
+
+const label = (type) => _(labels[type]);
+
+export default {
+    CONFIGURING,
+    IN_PROGRESS,
+    READY,
+    ERROR,
+    label
+};

--- a/src/lib/wicked/adapter.js
+++ b/src/lib/wicked/adapter.js
@@ -160,7 +160,7 @@ class WickedAdapter {
      * @param {Connection} connection - Connection to be removed
      * @return {Promise} Result of the operation
      */
-    removeConnection(connection) {
+    deleteConnection(connection) {
         return new Promise((resolve, reject) => {
             this.deleteConnectionConfig(connection)
                     .then(() => resolve(connection))


### PR DESCRIPTION
Set a flag in the interface which indicates that the configuration is being changed (adding, updating or deleting the connection).

![configure-interface](https://user-images.githubusercontent.com/15836/99679645-17467b00-2a74-11eb-980f-9cc9880293c8.gif)



## To do

- [x] Improve testing of the network context.
- [x] Determine whether the `exists` attribute is still needed.