### PR TITLE
Exclude some wicked errors when reloading a connection

### DIFF
--- a/src/lib/wicked/adapter.js
+++ b/src/lib/wicked/adapter.js
@@ -284,7 +284,7 @@ class WickedAdapter {
     reloadConnection(name) {
         return new Promise((resolve, reject) => {
             this.client.reloadConnection(name)
-                    .then((name) => resolve(name))
+                    .then(resolve)
                     .catch(error => {
                         if (EXCLUDED_ERROR_CODES.includes(error.exit_status)) {
                             resolve(name);

--- a/src/lib/wicked/adapter.js
+++ b/src/lib/wicked/adapter.js
@@ -26,6 +26,22 @@ import model from '../model';
 import { SysconfigFile, IfcfgFile, IfrouteFile } from './files';
 
 /**
+ * A collection of Wicked error codes that will be not reported to the user because they do not stop
+ * the interface/connection from working.
+ *
+ * @see https://github.com/openSUSE/wicked/blob/ab01fdf1eb1b17ce74bb41dd0bc8186e2aaa4880/include/wicked/constants.h#L274-L292
+ */
+const EXCLUDED_ERROR_CODES = [
+    159, /* no configuration found */
+    162, /* dev is up, but setup is incomplete */
+    163, /* up, config changed, reload advised */
+    164, /* dev is up and has masterdev */
+    165, /* ifcheck state lower than expected */
+    166, /* interface is in persistent mode */
+    167, /* user is allowed to configure the interface */
+];
+
+/**
  * This class is responsible for retrieving and updating wicked's configuration.
  *
  * It relies on WickedClient to get the needed information from Wicked. However,
@@ -266,7 +282,17 @@ class WickedAdapter {
      * @return {Promise} Result of the operation
      */
     reloadConnection(name) {
-        return this.client.reloadConnection(name);
+        return new Promise((resolve, reject) => {
+            this.client.reloadConnection(name)
+                    .then((name) => resolve(name))
+                    .catch(error => {
+                        if (EXCLUDED_ERROR_CODES.includes(error.exit_status)) {
+                            resolve(name);
+                        } else {
+                            reject(error);
+                        }
+                    });
+        });
     }
 }
 

--- a/src/lib/wicked/adapter.test.js
+++ b/src/lib/wicked/adapter.test.js
@@ -135,7 +135,7 @@ describe('#reloadConnection', () => {
         reloadConnectionMock.mockClear();
     });
 
-    it('returns the conneciton name if everything works', async () => {
+    it('returns the connection name if everything works', async () => {
         reloadConnectionMock.mockImplementation(name => Promise.resolve(name));
 
         const client = new Client();
@@ -158,7 +158,7 @@ describe('#reloadConnection', () => {
     });
 
     it('rejects if there is a not ignored error', async () => {
-        const error = { message: "This error should be ignored", exit_status: 157 };
+        const error = { message: "This error should not be ignored", exit_status: 157 };
 
         reloadConnectionMock.mockImplementation(name => Promise.reject(error));
 

--- a/src/lib/wicked/adapter.test.js
+++ b/src/lib/wicked/adapter.test.js
@@ -119,3 +119,52 @@ describe('#interfaces', () => {
         });
     });
 });
+
+describe('#reloadConnection', () => {
+    const reloadConnectionMock = jest.fn();
+
+    beforeAll(() => {
+        Client.mockImplementation(() => {
+            return {
+                reloadConnection: reloadConnectionMock
+            };
+        });
+    });
+
+    afterAll(() => {
+        reloadConnectionMock.mockClear();
+    });
+
+    it('returns the conneciton name if everything works', async () => {
+        reloadConnectionMock.mockImplementation(name => Promise.resolve(name));
+
+        const client = new Client();
+        const adapter = new Adapter(client);
+
+        const name = await adapter.reloadConnection("eth0");
+        expect(name).toEqual("eth0");
+    });
+
+    it('returns the connection name even if there is a known and ignored error', async () => {
+        const error = { message: "This error should be ignored", exit_status: 162 };
+
+        reloadConnectionMock.mockImplementation(name => Promise.reject(error));
+
+        const client = new Client();
+        const adapter = new Adapter(client);
+
+        const name = await adapter.reloadConnection("eth0");
+        expect(name).toEqual("eth0");
+    });
+
+    it('rejects if there is a not ignored error', async () => {
+        const error = { message: "This error should be ignored", exit_status: 157 };
+
+        reloadConnectionMock.mockImplementation(name => Promise.reject(error));
+
+        const client = new Client();
+        const adapter = new Adapter(client);
+
+        await expect(adapter.reloadConnection("eth0")).rejects.toEqual(error);
+    });
+});


### PR DESCRIPTION
Sometimes wicked returns some exit status codes that are not errors or do not mean that connection is not working. So, let's ignore them.