### PR TITLE
DNS: Show link text when the options are empty

### DIFF
--- a/src/components/DnsSettings.js
+++ b/src/components/DnsSettings.js
@@ -31,7 +31,7 @@ const PolicyDetails = ({ onClick, dns }) => {
     return (
         <>
             <dt>{_("Policy")}</dt>
-            <dd><a href="#" onClick={onClick}>{policy}</a></dd>
+            <dd><a href="#" onClick={onClick}>{policy || _("Disabled")}</a></dd>
         </>
     );
 };
@@ -42,7 +42,7 @@ const SearchListDetails = ({ onClick, dns }) => {
     return (
         <>
             <dt>{_("Search list")}</dt>
-            <dd><a href="#" onClick={onClick}>{searchList.join(" ")}</a></dd>
+            <dd><a href="#" onClick={onClick}>{(searchList.length == 0) ? _("Empty") : searchList.join(" ")}</a></dd>
         </>
     );
 };
@@ -53,7 +53,7 @@ const NameServersDetails = ({ onClick, dns }) => {
     return (
         <>
             <dt>{_("Name servers")}</dt>
-            <dd><a href="#" onClick={onClick}>{nameServers.join(" ")}</a></dd>
+            <dd><a href="#" onClick={onClick}>{(nameServers.length == 0) ? _("Empty") : nameServers.join(" ")}</a></dd>
         </>
     );
 };

--- a/src/lib/wicked/adapter.js
+++ b/src/lib/wicked/adapter.js
@@ -136,8 +136,10 @@ class WickedAdapter {
         const filePath = `/etc/sysconfig/network/config`;
         const file = await new SysconfigFile(filePath).read();
         const policy = file.get("NETCONFIG_DNS_POLICY", "");
-        const nameServers = file.get("NETCONFIG_DNS_STATIC_SERVERS", "").split(" ");
-        const searchList = file.get("NETCONFIG_DNS_STATIC_SEARCHLIST", "").split(" ");
+        const nameServers = file.get("NETCONFIG_DNS_STATIC_SERVERS", "").split(" ")
+                .filter(Boolean);
+        const searchList = file.get("NETCONFIG_DNS_STATIC_SEARCHLIST", "").split(" ")
+                .filter(Boolean);
 
         return model.createDnsSettings({ policy, nameServers, searchList });
     }


### PR DESCRIPTION
It will show the `Empty` link text when there are no **Name Servers** or no **Search Domains**.

The initialization of both variables have been fixed too as it was initialized to an array with an empty string instead of an empty array.

There is still an issue pending:

https://github.com/openSUSE/cockpit-wicked/blob/42ac5fddd956c55c5ff73f376d7f31d002b5b7a6/src/lib/wicked/files.js#L266

When the set of the options is called with an empty string, then, it is commented. We probably should do that only when the value is undefined or null.