### PR TITLE
Respect empty values when writing sysconfig files

### DIFF
--- a/src/lib/wicked/files.js
+++ b/src/lib/wicked/files.js
@@ -193,7 +193,7 @@ class SysconfigParser {
      * @return {Array<SysconfigFileLine>} An array of objects describing each line
      */
     parse(text) {
-        const keyValueLine = new RegExp(/^ *(#)? *([A-Za-z_0-9]+) *= *"?([^"]+)"?/);
+        const keyValueLine = new RegExp(/^ *(#)? *([A-Za-z_0-9]+) *= *"?([^"]*)"?/);
 
         const lines = text.split(/\r?\n/);
         return lines.reduce((content, line) => {

--- a/src/lib/wicked/files.js
+++ b/src/lib/wicked/files.js
@@ -256,14 +256,17 @@ class SysconfigFile {
      */
     set(key, value) {
         const line = this.data.find(l => l.key === key);
+        const someValue = (value !== undefined && value !== null);
 
-        if (!line && value) {
+        if (!line && someValue) {
             this.data.push({ key, value, commented: false });
-        } else if (line && value) {
-            line.value = value;
-            line.commented = false;
-        } else if (line && !value) {
-            line.commented = true;
+        } else if (line) {
+            if (someValue) {
+                line.value = value;
+                line.commented = false;
+            } else {
+                line.commented = true;
+            }
         }
     }
 

--- a/src/lib/wicked/files.test.js
+++ b/src/lib/wicked/files.test.js
@@ -120,15 +120,27 @@ describe('SysconfigParser', () => {
     });
 
     describe('#parse', () => {
-        const content = '## Type: boolean\n## Default: "no"\n\n WICKED_DEBUG="yes"\n#WICKED_LOG_LEVEL=info';
+        const content = [
+            '## Type: boolean',
+            '## Default: "no"',
+            '',
+            'DEBUG="yes"',
+            '#LOG_LEVEL="info"',
+            'MTU=1500',
+            'LINK_REQUIRED=',
+            'ZONE=""'
+        ].join('\n');
 
         it('returns an array containing one object for each line', () => {
             expect(parser.parse(content)).toEqual([
                 { comment: '## Type: boolean' },
                 { comment: '## Default: "no"' },
                 { comment: '' },
-                { key: 'WICKED_DEBUG', value: 'yes', commented: false },
-                { key: 'WICKED_LOG_LEVEL', value: 'info', commented: true }
+                { key: 'DEBUG', value: 'yes', commented: false },
+                { key: 'LOG_LEVEL', value: 'info', commented: true },
+                { key: 'MTU', value: '1500', commented: false },
+                { key: 'LINK_REQUIRED', value: '', commented: false },
+                { key: 'ZONE', value: '', commented: false }
             ]);
         });
     });

--- a/src/lib/wicked/files.test.js
+++ b/src/lib/wicked/files.test.js
@@ -143,14 +143,14 @@ describe('SysconfigFile', () => {
     const readFn = () => {
         return new Promise((resolve, reject) => {
             process.nextTick(() => {
-                resolve(fileContent);
+                resolve([...fileContent]);
             });
         });
     };
 
     const replaceFn = jest.fn();
 
-    const file = new SysconfigFile('/foo/bar');
+    const file = new SysconfigFile('/tmp/foo/bar');
 
     describe('get', () => {
         beforeAll(() => {
@@ -192,12 +192,14 @@ describe('SysconfigFile', () => {
             file.update({
                 NAME: 'eth0',
                 BOOTPROTO: undefined,
-                STARTMODE: 'ifplugd'
+                STARTMODE: 'ifplugd',
+                IPADDR: ''
             });
 
             expect(file.get('NAME')).toEqual('eth0');
             expect(file.get('BOOTPROTO')).toBeUndefined();
             expect(file.get('STARTMODE')).toEqual('ifplugd');
+            expect(file.get('IPADDR')).toEqual('');
         });
     });
 
@@ -207,14 +209,16 @@ describe('SysconfigFile', () => {
             file.update({
                 NAME: 'eth0',
                 BOOTPROTO: undefined,
-                STARTMODE: 'ifplugd'
+                STARTMODE: 'ifplugd',
+                IPADDR: ''
             });
             file.write();
 
             expect(replaceFn).toHaveBeenCalledWith([
                 { key: 'NAME', value: 'eth0', commented: false },
                 { key: 'BOOTPROTO', value: 'dhcp', commented: true },
-                { key: 'STARTMODE', value: 'ifplugd', commented: false }
+                { key: 'STARTMODE', value: 'ifplugd', commented: false },
+                { key: 'IPADDR', value: '', commented: false }
             ]);
         });
     });


### PR DESCRIPTION
Fixes two issues:

* Respect empty values when writing sysconfig files.
* Parse correctly empty values, so they do not get duplicated.