### PR TITLE
Improved bonding support 

### DIFF
--- a/src/components/BondForm.js
+++ b/src/components/BondForm.js
@@ -106,6 +106,7 @@ const BondForm = ({ isOpen, onClose, connection }) => {
             >
                 <TextInput
                     isRequired
+                    isDisabled={isEditing}
                     id="interface-name"
                     value={name}
                     onChange={setName}

--- a/src/components/BondForm.js
+++ b/src/components/BondForm.js
@@ -44,7 +44,7 @@ const BondForm = ({ isOpen, onClose, connection }) => {
     const isEditing = !!connection;
     const [name, setName] = useState(connection?.name || "");
     const [mode, setMode] = useState(bond?.mode || bondingModes.ACTIVE_BACKUP);
-    const [options, setOptions] = useState(bond?.options || "");
+    const [options, setOptions] = useState(bond?.options || "miimon=100");
     const [selectedInterfaces, setSelectedInterfaces] = useState(bond?.interfaces || []);
     const [candidateInterfaces, setCandidateInterfaces] = useState([]);
     const { interfaces } = useNetworkState();
@@ -52,7 +52,7 @@ const BondForm = ({ isOpen, onClose, connection }) => {
 
     useEffect(() => {
         if (isEditing) {
-            setCandidateInterfaces(Object.values(interfaces).filter(i => i.id !== connection.id));
+            setCandidateInterfaces(Object.values(interfaces).filter(i => i.name !== connection.name));
         } else {
             setCandidateInterfaces(Object.values(interfaces));
         }

--- a/src/components/BridgeForm.js
+++ b/src/components/BridgeForm.js
@@ -88,6 +88,7 @@ const BridgeForm = ({ isOpen, onClose, connection }) => {
             >
                 <TextInput
                     isRequired
+                    isDisabled={isEditing}
                     id="interface-name"
                     value={name}
                     onChange={setName}

--- a/src/components/InterfaceDetails.js
+++ b/src/components/InterfaceDetails.js
@@ -90,7 +90,7 @@ const wirelessDetails = (iface, connection) => {
 const ipV4Details = (connection) => {
     return (
         <>
-            <dt>{_("IPv4 settings")}</dt>
+            <dt>{_("IPv4")}</dt>
             <dd><IPSettingsLink connection={connection} /></dd>
         </>
     );
@@ -99,7 +99,7 @@ const ipV4Details = (connection) => {
 const ipV6Details = (connection) => {
     return (
         <>
-            <dt>{_("IPv6 settings")}</dt>
+            <dt>{_("IPv6")}</dt>
             <dd><IPSettingsLink connection={connection} ipVersion='ipv6' /></dd>
         </>
     );

--- a/src/context/reducers.js
+++ b/src/context/reducers.js
@@ -89,17 +89,16 @@ export function interfacesReducer(state, action) {
 
         return {
             ...state,
-            [iface.id]: { ...iface, status: interfaceStatus.CHANGING }
+            [iface.id]: { ...iface, status: interfaceStatus.CHANGING, error: null }
         };
     }
 
     case actionTypes.UPDATE_CONNECTION: {
         const { name } = action.payload;
         const iface = Object.values(state).find(i => i.name === name);
-        const { error, ...updatedIface } = iface;
         return {
             ...state,
-            [iface.id]: { ...updatedIface, status: interfaceStatus.CHANGING }
+            [iface.id]: { ...iface, status: interfaceStatus.CHANGING, error: null }
         };
     }
 
@@ -110,7 +109,7 @@ export function interfacesReducer(state, action) {
         if (!conn.virtual) {
             return {
                 ...state,
-                [iface.id]: { ...iface, status: interfaceStatus.CHANGING }
+                [iface.id]: { ...iface, status: interfaceStatus.CHANGING, error: null }
             };
         }
 

--- a/src/context/reducers.test.js
+++ b/src/context/reducers.test.js
@@ -118,7 +118,7 @@ describe('interfacesReducer', () => {
             const newState = interfacesReducer(state, action);
 
             expect(newState).toEqual({
-                [eth0.id]: expect.objectContaining({ status: interfaceStatus.CHANGING })
+                [eth0.id]: expect.objectContaining({ status: interfaceStatus.CHANGING, error: null })
             });
         });
     });
@@ -133,7 +133,7 @@ describe('interfacesReducer', () => {
 
             const { [eth0.id]: newIface } = newState;
             expect(newIface.status).toEqual(interfaceStatus.CHANGING);
-            expect(newIface.error).toBeUndefined();
+            expect(newIface.error).toBeNull();
         });
     });
 
@@ -142,7 +142,7 @@ describe('interfacesReducer', () => {
             const conn = createConnection({ name: 'eth0' });
             const eth0 = createInterface({ name: 'eth0' });
             const state = { [eth0.id]: eth0 };
-            const action = { type: actionTypes.DELETE_CONNECTION, payload: conn };
+            const action = { type: actionTypes.DELETE_CONNECTION, payload: conn, error: null };
             const newState = interfacesReducer(state, action);
 
             const { [eth0.id]: newIface } = newState;

--- a/src/lib/wicked/connections.js
+++ b/src/lib/wicked/connections.js
@@ -180,9 +180,10 @@ const propsByWirelessAuthMode = {
 
 const propsByConnectionType = {
     [interfaceType.BONDING]: ({ bond }) => {
-        // FIXME: wicked returns a 'miimon' element
-        const { slaves = [], mode = bondingMode.ACTIVE_BACKUP, options = "" } = bond;
-        return { bond: { interfaces: slaves, mode, options } };
+        const { slaves = [], mode = bondingMode.ACTIVE_BACKUP, options = "", miimon = { frequency: "100" } } = bond;
+        const interfaces = slaves.map(i => i.device);
+        const opts = [`miimon=${miimon.frequency}`, options].join(' ');
+        return { bond: { interfaces, mode, options: opts } };
     },
     [interfaceType.BRIDGE]: ({ bridge }) => {
         const { ports } = bridge;

--- a/src/lib/wicked/connections.test.js
+++ b/src/lib/wicked/connections.test.js
@@ -90,7 +90,7 @@ describe('#createConnection', () => {
             bond: {
                 mode: 'balance-rr',
                 miimon: { frequency: "100", "carrier-detect": "netif" },
-                slaves: ['eth0', 'eth1'],
+                slaves: [{ device: 'eth0' }, { device: 'eth1' }],
                 options: 'some-option'
             },
         };
@@ -100,7 +100,7 @@ describe('#createConnection', () => {
             expect(conn.bond).toEqual({
                 mode: bondingMode.BALANCE_RR,
                 interfaces: ['eth0', 'eth1'],
-                options: 'some-option'
+                options: 'miimon=100 some-option'
             });
         });
     });

--- a/src/lib/wicked/utils.js
+++ b/src/lib/wicked/utils.js
@@ -23,6 +23,7 @@ import interfaceType from '../model/interfaceType';
 
 const PROPERTY_TO_TYPE = {
     bond: interfaceType.BONDING,
+    bonding: interfaceType.BONDING,
     bridge: interfaceType.BRIDGE,
     vlan: interfaceType.VLAN,
     wireless: interfaceType.WIRELESS


### PR DESCRIPTION
* Fixes to bonding support:
  - Interface type detection.
  - Correctly read the list of interfaces from wicked.
  - Set miimon=100 as an option by default (otherwise, the bond will not be properly reported by Wicked later).
  - Read miimon value from Wicked.
  - Properly filter the bonding name in the list of devices.
* Other changes:
  - Do not allow changing bond and bridge names once they are created.
  - Reset error message on adding/deleting a configuration.
  - Replace "IPv? settings" label with just "IPv?".