### PR TITLE
Do not crash when adding a route

### DIFF
--- a/src/context/reducers.js
+++ b/src/context/reducers.js
@@ -134,7 +134,10 @@ export function interfacesReducer(state, action) {
 export function routesReducer(state, action) {
     switch (action.type) {
     case actionTypes.SET_ROUTES: {
-        return action.payload.reduce((all, routeData) => {
+        // Ensure we're going to work with an array
+        const routes = Object.values(action.payload);
+
+        return routes.reduce((all, routeData) => {
             const route = createRoute(routeData);
             return { ...all, [route.id]: route };
         }, {});

--- a/src/context/reducers.test.js
+++ b/src/context/reducers.test.js
@@ -180,17 +180,33 @@ describe('interfacesReducer', () => {
 
 describe('routesReducer', () => {
     describe('SET_ROUTES', () => {
-        it('set the routes', () => {
-            const action = {
-                type: actionTypes.SET_ROUTES, payload: [
-                    { gateway: '192.168.1.1', isDefault: true }
-                ]
-            };
-            const newState = routesReducer({}, action);
+        let payload;
+        const type = actionTypes.SET_ROUTES;
 
-            expect(Object.values(newState)).toEqual([
-                expect.objectContaining({ gateway: '192.168.1.1', isDefault: true })
-            ]);
+        describe('when payload is an array holding routes', () => {
+            payload = [{ gateway: '192.168.1.1', isDefault: true }];
+
+            it('set the routes', () => {
+                const action = { type, payload };
+                const newState = routesReducer({}, action);
+
+                expect(Object.values(newState)).toEqual([
+                    expect.objectContaining({ gateway: '192.168.1.1', isDefault: true })
+                ]);
+            });
+        });
+
+        describe('when payload is an object holding routes', () => {
+            payload = { 0: { id: 0, gateway: '192.168.1.1', isDefault: true } };
+
+            it('set the routes', () => {
+                const action = { type, payload };
+                const newState = routesReducer({}, action);
+
+                expect(Object.values(newState)).toEqual([
+                    expect.objectContaining({ gateway: '192.168.1.1', isDefault: true })
+                ]);
+            });
         });
     });
 });


### PR DESCRIPTION
### Problem

The application crash when trying to _redraw_ the routes list just after adding a new one. This happens because the reducer is expecting to receive an `Array` holding the routes, but is getting an `Object` instead.

### Quick fix

To ensure that reducer is going to work with an Array no matter what it received by using `Object.values`.

Fixes https://github.com/openSUSE/cockpit-wicked/issues/92

### Notes

This should be fixed in a better way when addressing https://github.com/openSUSE/cockpit-wicked/issues/49

