### PR TITLE
Split managed and unmanaged interfaces

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -24,7 +24,6 @@ import cockpit from 'cockpit';
 import {
     Page,
     PageSection,
-    PageSectionVariants,
     Tab,
     TabTitleText,
     Tabs,
@@ -79,10 +78,9 @@ export const Application = () => {
 
     return (
         <NetworkProvider>
-            <Page>
+            <Page className="network">
                 { checkingService && <StatusBar showSpinner>{_("Checking if service is active...")}</StatusBar> }
-
-                <PageSection padding={{ default: 'noPadding' }} variant={PageSectionVariants.light}>
+                <PageSection>
                     { renderContent() }
                 </PageSection>
             </Page>

--- a/src/app.scss
+++ b/src/app.scss
@@ -92,7 +92,7 @@ p {
            calc(var(--pf-c-page__main-section--PaddingLeft) * -1);
         padding: var(--pf-c-page__main-section--PaddingTop)
            var(--pf-c-page__main-section--PaddingRight)
-           var(--pf-c-page__main-section--PaddingBottom)
+           0
            var(--pf-c-page__main-section--PaddingLeft);
         background: var(--pf-global--Color--light-100);
     }

--- a/src/app.scss
+++ b/src/app.scss
@@ -104,6 +104,10 @@ p {
     .pf-c-card__title h2 {
         font-size: var(--pf-global--FontSize--2xl);
     }
+
+    .pf-c-tab-content:focus {
+        outline: none;
+    }
 }
 
 .interfaces-list {

--- a/src/app.scss
+++ b/src/app.scss
@@ -91,6 +91,10 @@ p {
     .pf-c-card {
         margin-bottom: var(--pf-global--spacer--md);
     }
+
+    .pf-c-card__title h2 {
+        font-size: var(--pf-global--FontSize--2xl);
+    }
 }
 
 .interfaces-list {

--- a/src/app.scss
+++ b/src/app.scss
@@ -83,6 +83,16 @@ p {
     }
 }
 
+.network {
+    .pf-c-tab-content {
+        padding-top: var(--pf-global--spacer--md);
+    }
+
+    .pf-c-card {
+        margin-bottom: var(--pf-global--spacer--md);
+    }
+}
+
 .interfaces-list {
     .pf-c-table__toggle .pf-c-button {
         padding-left: var(--pf-global--spacer--xs);

--- a/src/app.scss
+++ b/src/app.scss
@@ -84,8 +84,19 @@ p {
 }
 
 .network {
-    .pf-c-tab-content {
-        padding-top: var(--pf-global--spacer--md);
+    /** Make tabs looks like a navigation component */
+    .pf-c-tabs {
+        margin:
+           calc(var(--pf-c-page__main-section--PaddingTop) * -1)
+           calc(var(--pf-c-page__main-section--PaddingRight) * -1)
+           var(--pf-c-page__main-section--PaddingTop)
+           calc(var(--pf-c-page__main-section--PaddingLeft) * -1);
+        padding:
+           var(--pf-c-page__main-section--PaddingTop)
+           var(--pf-c-page__main-section--PaddingRight)
+           var(--pf-c-page__main-section--PaddingBottom)
+           var(--pf-c-page__main-section--PaddingLeft);
+         background: var(	--pf-global--Color--light-100);
     }
 
     .pf-c-card {

--- a/src/app.scss
+++ b/src/app.scss
@@ -86,17 +86,15 @@ p {
 .network {
     /** Make tabs looks like a navigation component */
     .pf-c-tabs {
-        margin:
-           calc(var(--pf-c-page__main-section--PaddingTop) * -1)
+        margin: calc(var(--pf-c-page__main-section--PaddingTop) * -1)
            calc(var(--pf-c-page__main-section--PaddingRight) * -1)
            var(--pf-c-page__main-section--PaddingTop)
            calc(var(--pf-c-page__main-section--PaddingLeft) * -1);
-        padding:
-           var(--pf-c-page__main-section--PaddingTop)
+        padding: var(--pf-c-page__main-section--PaddingTop)
            var(--pf-c-page__main-section--PaddingRight)
            var(--pf-c-page__main-section--PaddingBottom)
            var(--pf-c-page__main-section--PaddingLeft);
-         background: var(	--pf-global--Color--light-100);
+        background: var(--pf-global--Color--light-100);
     }
 
     .pf-c-card {

--- a/src/components/InterfaceDetails.js
+++ b/src/components/InterfaceDetails.js
@@ -128,25 +128,21 @@ const InterfaceDetails = ({ iface, connection, changeConnectionState, deleteConn
     };
 
     const renderActions = () => {
-        if (!connection.exists) return;
-
         return (
             <Toolbar>
                 <ToolbarContent>
-                    <ToolbarItem>
-                        <DeleteConnection connection={connection} deleteConnection={deleteConnection} />
-                    </ToolbarItem>
-
-                    {
-                        iface &&
+                    { connection.exists &&
                         <ToolbarItem>
-                            <Switch
-                              id={`status_${iface.name}}`}
-                              isChecked={iface.link}
-                              onChange={() => changeConnectionState(connection, !iface.link)}
-                            />
-                        </ToolbarItem>
-                    }
+                            <DeleteConnection connection={connection} deleteConnection={deleteConnection} />
+                        </ToolbarItem>}
+
+                    <ToolbarItem>
+                        <Switch
+                          id={`status_${iface.name}}`}
+                          isChecked={iface.link}
+                          onChange={() => changeConnectionState(connection, !iface.link)}
+                        />
+                    </ToolbarItem>
                 </ToolbarContent>
             </Toolbar>
         );

--- a/src/components/InterfacesList.js
+++ b/src/components/InterfacesList.js
@@ -22,7 +22,6 @@
 import cockpit from "cockpit";
 import React, { useState, useEffect, useCallback } from 'react';
 import {
-    Spinner,
     Table,
     TableBody,
     TableHeader,
@@ -31,6 +30,7 @@ import {
     expandable,
     truncate
 } from '@patternfly/react-table';
+import { Spinner } from '@patternfly/react-core';
 import AlertIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import InterfaceDetails from "./InterfaceDetails";
 import interfaceType from '../lib/model/interfaceType';

--- a/src/components/InterfacesList.js
+++ b/src/components/InterfacesList.js
@@ -21,8 +21,8 @@
 
 import cockpit from "cockpit";
 import React, { useState, useEffect, useCallback } from 'react';
-import { Card, CardBody, Spinner } from '@patternfly/react-core';
 import {
+    Spinner,
     Table,
     TableBody,
     TableHeader,
@@ -159,21 +159,17 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
     }, [buildRows]);
 
     return (
-        <Card>
-            <CardBody>
-                <Table
-                    aria-label="Networking interfaces"
-                    variant={TableVariant.compact}
-                    onCollapse={onCollapseFn()}
-                    className="interfaces-list"
-                    cells={columns}
-                    rows={rows}
-                >
-                    <TableHeader />
-                    <TableBody />
-                </Table>
-            </CardBody>
-        </Card>
+        <Table
+            aria-label="Networking interfaces"
+            variant={TableVariant.compact}
+            onCollapse={onCollapseFn()}
+            className="interfaces-list"
+            cells={columns}
+            rows={rows}
+        >
+            <TableHeader />
+            <TableBody />
+        </Table>
     );
 };
 

--- a/src/components/InterfacesList.test.js
+++ b/src/components/InterfacesList.test.js
@@ -20,11 +20,11 @@
  */
 
 import React from "react";
-import { render, screen } from "@testing-library/react";
 import userEvent from '@testing-library/user-event';
+import { screen } from "@testing-library/react";
 import '@testing-library/jest-dom/extend-expect';
-import { NetworkProvider } from '../context/network';
 import InterfacesList from "./InterfacesList";
+import { customRender } from "../../test/helpers";
 import { createInterface } from '../lib/model/interfaces';
 import { createConnection } from '../lib/model/connections';
 import { createAddressConfig } from '../lib/model/address';
@@ -43,18 +43,10 @@ const connections = [
     createConnection({ id: 1, name: 'eth0' })
 ];
 
-const customRender = (ui, { providerProps, ...renderOptions }) => {
-    return render(
-        <NetworkProvider {...providerProps}>{ui}</NetworkProvider>,
-        renderOptions
-    );
-};
-
 describe('InterfacesList', () => {
     test('shows the interfaces names and IPs', () => {
         customRender(
-            <InterfacesList interfaces={interfaces} connections={connections} />,
-            { value: { connections, interfaces } }
+            <InterfacesList interfaces={interfaces} connections={connections} />
         );
 
         expect(screen.getByText('eth0')).toBeInTheDocument();
@@ -63,8 +55,7 @@ describe('InterfacesList', () => {
 
     test('display details', () => {
         customRender(
-            <InterfacesList interfaces={interfaces} connections={connections} />,
-            { value: { connections, interfaces } }
+            <InterfacesList interfaces={interfaces} connections={connections} />
         );
 
         expect(screen.getByText('00:d8:23:93:14:cc')).not.toBeVisible();
@@ -78,8 +69,7 @@ describe('InterfacesList', () => {
 
     test('when the connection is not configured', () => {
         customRender(
-            <InterfacesList interfaces={interfaces} connections={[]} />,
-            { value: { connections, interfaces } }
+            <InterfacesList interfaces={interfaces} connections={[]} />
         );
 
         expect(screen.getByText('eth0')).toBeInTheDocument();

--- a/src/components/InterfacesTab.js
+++ b/src/components/InterfacesTab.js
@@ -45,6 +45,24 @@ const InterfacesTab = () => {
     const unmanagedInterfacesList = interfaces ? Object.values(interfaces).filter((i) => !managedInterfacesList.includes(i)) : [];
     const connectionsList = connections ? Object.values(connections) : [];
 
+    const renderUnmanagedInterfaces = () => {
+        if (unmanagedInterfacesList.length === 0) return;
+
+        return (
+            <Card>
+                <CardHeader>
+                    <CardActions />
+                    <CardTitle>
+                        <Text component={TextVariants.h2}>{_("Unmanaged Interfaces")}</Text>
+                    </CardTitle>
+                </CardHeader>
+                <CardBody>
+                    <UnmanagedInterfacesList interfaces={unmanagedInterfacesList} />
+                </CardBody>
+            </Card>
+        );
+    };
+
     return (
         <>
             <Card>
@@ -60,18 +78,7 @@ const InterfacesTab = () => {
                     <InterfacesList interfaces={managedInterfacesList} connections={connectionsList} />
                 </CardBody>
             </Card>
-            { (unmanagedInterfacesList.length > 0) &&
-                <Card>
-                    <CardHeader>
-                        <CardActions />
-                        <CardTitle>
-                            <Text component={TextVariants.h2}>{_("Unmanaged Interfaces")}</Text>
-                        </CardTitle>
-                    </CardHeader>
-                    <CardBody>
-                        <UnmanagedInterfacesList interfaces={unmanagedInterfacesList} />
-                    </CardBody>
-                </Card>}
+            { renderUnmanagedInterfaces() }
         </>
     );
 };

--- a/src/components/InterfacesTab.js
+++ b/src/components/InterfacesTab.js
@@ -27,7 +27,7 @@ import cockpit from 'cockpit';
 import {
     useNetworkDispatch, useNetworkState, fetchInterfaces, fetchConnections, listenToInterfacesChanges
 } from '../context/network';
-import { Card, CardActions, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
+import { Card, CardActions, CardBody, CardHeader, CardTitle, Text, TextVariants } from '@patternfly/react-core';
 
 const _ = cockpit.gettext;
 
@@ -49,24 +49,29 @@ const InterfacesTab = () => {
         <>
             <Card>
                 <CardHeader>
-                    <CardTitle>{_("Interfaces")}</CardTitle>
                     <CardActions>
                         <AddConnectionMenu />
                     </CardActions>
+                    <CardTitle>
+                        <Text component={TextVariants.h2}>{_("Interfaces")}</Text>
+                    </CardTitle>
                 </CardHeader>
                 <CardBody>
                     <InterfacesList interfaces={managedInterfacesList} connections={connectionsList} />
                 </CardBody>
             </Card>
-            <Card>
-                <CardHeader>
-                    <CardTitle>{_("Unmanaged Interfaces")}</CardTitle>
-                </CardHeader>
-                <CardBody>
-                    <UnmanagedInterfacesList interfaces={unmanagedInterfacesList} />
-                </CardBody>
-            </Card>
-
+            { (unmanagedInterfacesList.length > 0) &&
+                <Card>
+                    <CardHeader>
+                        <CardActions />
+                        <CardTitle>
+                            <Text component={TextVariants.h2}>{_("Unmanaged Interfaces")}</Text>
+                        </CardTitle>
+                    </CardHeader>
+                    <CardBody>
+                        <UnmanagedInterfacesList interfaces={unmanagedInterfacesList} />
+                    </CardBody>
+                </Card>}
         </>
     );
 };

--- a/src/components/InterfacesTab.js
+++ b/src/components/InterfacesTab.js
@@ -21,11 +21,15 @@
 
 import React, { useEffect } from 'react';
 import InterfacesList from './InterfacesList';
+import UnmanagedInterfacesList from './UnmanagedInterfacesList';
 import AddConnectionMenu from './AddConnectionMenu';
+import cockpit from 'cockpit';
 import {
     useNetworkDispatch, useNetworkState, fetchInterfaces, fetchConnections, listenToInterfacesChanges
 } from '../context/network';
-import { Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
+import { Card, CardActions, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
+
+const _ = cockpit.gettext;
 
 const InterfacesTab = () => {
     const dispatch = useNetworkDispatch();
@@ -37,19 +41,32 @@ const InterfacesTab = () => {
         listenToInterfacesChanges(dispatch);
     }, [dispatch]);
 
-    const interfacesList = interfaces ? Object.values(interfaces) : [];
+    const managedInterfacesList = interfaces ? Object.values(interfaces).filter((i) => i.managed || !i.virtual) : [];
+    const unmanagedInterfacesList = interfaces ? Object.values(interfaces).filter((i) => !managedInterfacesList.includes(i)) : [];
     const connectionsList = connections ? Object.values(connections) : [];
 
     return (
         <>
-            <Toolbar id="interfaces-toolbar">
-                <ToolbarContent>
-                    <ToolbarItem alignment={{ default: 'alignRight' }}>
+            <Card>
+                <CardHeader>
+                    <CardTitle>{_("Interfaces")}</CardTitle>
+                    <CardActions>
                         <AddConnectionMenu />
-                    </ToolbarItem>
-                </ToolbarContent>
-            </Toolbar>
-            <InterfacesList interfaces={interfacesList} connections={connectionsList} />
+                    </CardActions>
+                </CardHeader>
+                <CardBody>
+                    <InterfacesList interfaces={managedInterfacesList} connections={connectionsList} />
+                </CardBody>
+            </Card>
+            <Card>
+                <CardHeader>
+                    <CardTitle>{_("Unmanaged Interfaces")}</CardTitle>
+                </CardHeader>
+                <CardBody>
+                    <UnmanagedInterfacesList interfaces={unmanagedInterfacesList} />
+                </CardBody>
+            </Card>
+
         </>
     );
 };

--- a/src/components/RoutesList.js
+++ b/src/components/RoutesList.js
@@ -21,7 +21,6 @@
 
 import cockpit from "cockpit";
 import React, { useState, useEffect } from 'react';
-import { Card, CardBody } from '@patternfly/react-core';
 import { Table, TableHeader, TableBody, TableVariant } from '@patternfly/react-table';
 import { useNetworkDispatch, deleteRoute } from '../context/network';
 import RouteForm from './RouteForm';
@@ -75,20 +74,16 @@ const RoutesList = ({ routes }) => {
     return (
         <>
             { isFormOpen && <RouteForm isOpen={isFormOpen} route={route} onClose={() => setFormOpen(false)} /> }
-            <Card>
-                <CardBody>
-                    <Table
-                    aria-label="Default Routing Table"
-                    variant={TableVariant.compact}
-                    cells={columns}
-                    rows={rows}
-                    actions={actions}
-                    >
-                        <TableHeader />
-                        <TableBody />
-                    </Table>
-                </CardBody>
-            </Card>
+            <Table
+            aria-label="Default Routing Table"
+            variant={TableVariant.compact}
+            cells={columns}
+            rows={rows}
+            actions={actions}
+            >
+                <TableHeader />
+                <TableBody />
+            </Table>
         </>
     );
 };

--- a/src/components/RoutingTab.js
+++ b/src/components/RoutingTab.js
@@ -21,7 +21,7 @@
 
 import React, { useEffect } from 'react';
 import { useNetworkDispatch, useNetworkState, fetchRoutes } from '../context/network';
-import { Card, CardBody, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
+import { Card, CardActions, CardBody, CardHeader } from '@patternfly/react-core';
 import RoutesList from './RoutesList';
 import AddRoute from './AddRoute';
 
@@ -34,20 +34,16 @@ const RoutingTab = () => {
     const routesList = routes ? Object.values(routes) : [];
 
     return (
-        <>
-            <Toolbar id="routing-toolbar">
-                <ToolbarContent>
-                    <ToolbarItem alignment={{ default: 'alignRight' }}>
-                        <AddRoute />
-                    </ToolbarItem>
-                </ToolbarContent>
-            </Toolbar>
-            <Card>
-                <CardBody>
-                    <RoutesList routes={routesList} />
-                </CardBody>
-            </Card>
-        </>
+        <Card>
+            <CardHeader>
+                <CardActions>
+                    <AddRoute />
+                </CardActions>
+            </CardHeader>
+            <CardBody>
+                <RoutesList routes={routesList} />
+            </CardBody>
+        </Card>
     );
 };
 

--- a/src/components/UnmanagedInterfacesList.js
+++ b/src/components/UnmanagedInterfacesList.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) [2020] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import cockpit from "cockpit";
+import React, { useState, useEffect, useCallback } from 'react';
+import { Card, CardBody } from '@patternfly/react-core';
+import {
+    Table,
+    TableBody,
+    TableHeader,
+    TableVariant,
+    cellWidth,
+    truncate
+} from '@patternfly/react-table';
+import interfaceType from '../lib/model/interfaceType';
+import interfaceStatus from '../lib/model/interfaceStatus';
+
+const _ = cockpit.gettext;
+
+const UnmanagedInterfacesList = ({ interfaces = [], connections = [] }) => {
+    const [rows, setRows] = useState([]);
+
+    const columns = [
+        { title: _("Name") },
+        { title: _("Type") },
+        { title: _("Status"), transforms: [cellWidth(10)], cellTransforms: [truncate] },
+        { title: _("Addresses") }
+    ];
+
+    const interfaceAddresses = (iface) => {
+        if (iface.addresses.length === 0) return;
+
+        return iface.addresses.map(i => i.local).join(', ');
+    };
+
+    const renderStatusText = (iface) => {
+        const linkText = iface.link ? _('Up') : _('Down');
+
+        if (!iface.status || iface.status === interfaceStatus.READY) {
+            return linkText;
+        } else {
+            return interfaceStatus.label(iface.status);
+        }
+    };
+
+    /**
+     * Builds the needed structure for rendering the interfaces and their details in an expandable
+     * Patternfly/Table
+     */
+    const buildRows = useCallback(() => {
+        return interfaces.reduce((list, i) => {
+            list.push(
+                {
+                    cells: [
+                        i.name,
+                        interfaceType.label(i.type),
+                        renderStatusText(i),
+                        interfaceAddresses(i)
+                    ]
+                }
+            );
+
+            return list;
+        }, []);
+    }, [interfaces]);
+
+    useEffect(() => {
+        setRows(buildRows());
+    }, [buildRows]);
+
+    return (
+        <Card>
+            <CardBody>
+                <Table
+                    aria-label="Networking interfaces"
+                    variant={TableVariant.compact}
+                    className="interfaces-list"
+                    cells={columns}
+                    rows={rows}
+                >
+                    <TableHeader />
+                    <TableBody />
+                </Table>
+            </CardBody>
+        </Card>
+    );
+};
+
+export default UnmanagedInterfacesList;

--- a/src/components/UnmanagedInterfacesList.js
+++ b/src/components/UnmanagedInterfacesList.js
@@ -35,7 +35,7 @@ import interfaceStatus from '../lib/model/interfaceStatus';
 
 const _ = cockpit.gettext;
 
-const UnmanagedInterfacesList = ({ interfaces = [], connections = [] }) => {
+const UnmanagedInterfacesList = ({ interfaces = [] }) => {
     const [rows, setRows] = useState([]);
 
     const columns = [

--- a/src/components/UnmanagedInterfacesList.js
+++ b/src/components/UnmanagedInterfacesList.js
@@ -21,7 +21,6 @@
 
 import cockpit from "cockpit";
 import React, { useState, useEffect, useCallback } from 'react';
-import { Card, CardBody } from '@patternfly/react-core';
 import {
     Table,
     TableBody,
@@ -87,20 +86,16 @@ const UnmanagedInterfacesList = ({ interfaces = [] }) => {
     }, [buildRows]);
 
     return (
-        <Card>
-            <CardBody>
-                <Table
-                    aria-label="Networking interfaces"
-                    variant={TableVariant.compact}
-                    className="interfaces-list"
-                    cells={columns}
-                    rows={rows}
-                >
-                    <TableHeader />
-                    <TableBody />
-                </Table>
-            </CardBody>
-        </Card>
+        <Table
+            aria-label="Networking interfaces"
+            variant={TableVariant.compact}
+            className="interfaces-list"
+            cells={columns}
+            rows={rows}
+        >
+            <TableHeader />
+            <TableBody />
+        </Table>
     );
 };
 

--- a/src/components/UnmanagedInterfacesList.js
+++ b/src/components/UnmanagedInterfacesList.js
@@ -87,7 +87,7 @@ const UnmanagedInterfacesList = ({ interfaces = [] }) => {
 
     return (
         <Table
-            aria-label="Networking interfaces"
+            aria-label="Unmanaged networking interfaces"
             variant={TableVariant.compact}
             className="interfaces-list"
             cells={columns}

--- a/src/components/UnmanagedInterfacesList.test.js
+++ b/src/components/UnmanagedInterfacesList.test.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) [2020] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import '@testing-library/jest-dom/extend-expect';
+import UnmanagedInterfacesList from "./UnmanagedInterfacesList";
+import { createInterface } from '../lib/model/interfaces';
+import interfaceType from '../lib/model/interfaceType';
+import { createAddressConfig } from '../lib/model/address';
+import { customRender } from '../../test/helpers';
+
+const interfaces = [
+    createInterface(
+        {
+            name: 'virbr0',
+            type: interfaceType.BRIDGE,
+            managed: false,
+            addresses: [createAddressConfig({ local: '192.168.122.1/24' })]
+        }
+    )
+];
+
+describe('UnmanagedInterfacesList', () => {
+    test('shows the interfaces names and IPs', () => {
+        const { getByText } = customRender(
+            <UnmanagedInterfacesList interfaces={interfaces} />
+        );
+
+        expect(getByText('virbr0')).toBeInTheDocument();
+        expect(getByText('Bridge')).toBeInTheDocument();
+        expect(getByText('192.168.122.1/24')).toBeInTheDocument();
+    });
+});

--- a/src/lib/model/interfaceType.js
+++ b/src/lib/model/interfaceType.js
@@ -29,13 +29,17 @@ const WIRELESS = "wlan";
 const BONDING = "bond";
 const BRIDGE = "br";
 const VLAN = "vlan";
+const TUN = "tun";
+const TAP = "tap";
 
 const values = [
     ETHERNET,
     WIRELESS,
     BONDING,
     BRIDGE,
-    VLAN
+    VLAN,
+    TUN,
+    TAP,
 ];
 
 const labels = {
@@ -43,12 +47,14 @@ const labels = {
     [WIRELESS]: NC_("Wireless"),
     [BONDING]: NC_("Bonding"),
     [BRIDGE]: NC_("Bridge"),
-    [VLAN]: NC_("VLAN")
+    [VLAN]: NC_("VLAN"),
+    [TUN]: NC_("TUN"),
+    [TAP]: NC_("TAP"),
 };
 
 const label = (type) => _(labels[type]);
 
-const virtualTypes = [BONDING, BRIDGE, VLAN];
+const virtualTypes = [BONDING, BRIDGE, TUN, TAP, VLAN];
 const isVirtual = (type) => virtualTypes.includes(type);
 
 export default {
@@ -57,6 +63,8 @@ export default {
     BONDING,
     BRIDGE,
     VLAN,
+    TUN,
+    TAP,
     values,
     label,
     isVirtual

--- a/src/lib/model/interfaceType.js
+++ b/src/lib/model/interfaceType.js
@@ -28,7 +28,11 @@ const ETHERNET = "eth";
 const WIRELESS = "wlan";
 const BONDING = "bond";
 const BRIDGE = "br";
+const DUMMY = "dummy";
 const VLAN = "vlan";
+const VXLAN = "vxlan";
+const GRE = "gre";
+const SIT = "sit";
 const TUN = "tun";
 const TAP = "tap";
 
@@ -37,7 +41,11 @@ const values = [
     WIRELESS,
     BONDING,
     BRIDGE,
+    DUMMY,
     VLAN,
+    VXLAN,
+    GRE,
+    SIT,
     TUN,
     TAP,
 ];
@@ -47,14 +55,18 @@ const labels = {
     [WIRELESS]: NC_("Wireless"),
     [BONDING]: NC_("Bonding"),
     [BRIDGE]: NC_("Bridge"),
+    [DUMMY]: NC_("Dummy"),
     [VLAN]: NC_("VLAN"),
+    [VXLAN]: NC_("VXLAN"),
+    [GRE]: NC_("GRE"),
+    [SIT]: NC_("SIT"),
     [TUN]: NC_("TUN"),
     [TAP]: NC_("TAP"),
 };
 
 const label = (type) => _(labels[type]);
 
-const virtualTypes = [BONDING, BRIDGE, TUN, TAP, VLAN];
+const virtualTypes = [BONDING, BRIDGE, DUMMY, GRE, SIT, TUN, TAP, VXLAN, VLAN];
 const isVirtual = (type) => virtualTypes.includes(type);
 
 export default {
@@ -62,7 +74,11 @@ export default {
     WIRELESS,
     BONDING,
     BRIDGE,
+    DUMMY,
     VLAN,
+    VXLAN,
+    GRE,
+    SIT,
     TUN,
     TAP,
     values,

--- a/src/lib/model/interfaces.js
+++ b/src/lib/model/interfaces.js
@@ -54,7 +54,8 @@ export const createInterface = ({
     mac,
     type = "eth",
     link = true,
-    addresses = []
+    addresses = [],
+    managed = false
 }) => {
     const virtual = interfaceType.isVirtual(type);
     return {
@@ -66,6 +67,7 @@ export const createInterface = ({
         type,
         virtual,
         link,
-        addresses
+        addresses,
+        managed
     };
 };

--- a/src/lib/wicked/adapter.js
+++ b/src/lib/wicked/adapter.js
@@ -71,7 +71,7 @@ class WickedAdapter {
         conns.forEach(c => {
             if (!names.includes(c.name)) {
                 const virtualInterface = model.createInterface({
-                    name: c.name, type: c.type, virtual: true, link: false
+                    name: c.name, type: c.type, virtual: true, link: false, managed: true
                 });
                 ifaces.push(virtualInterface);
             }

--- a/src/lib/wicked/interfaces.js
+++ b/src/lib/wicked/interfaces.js
@@ -38,7 +38,7 @@ import { typeFromWicked } from './utils';
  * @return {Interface} Interface model object
  */
 const createInterface = (iface) => {
-    const { name, addresses: assignedAddresses } = iface.interface;
+    const { name, addresses: assignedAddresses, client_state } = iface.interface;
     const description = "";
 
     const ethtool = iface.ethtool || {};
@@ -51,8 +51,10 @@ const createInterface = (iface) => {
 
     const addresses = (assignedAddresses || []).map(model.createAddressConfig);
 
+    const managed = !!client_state?.config;
+
     return model.createInterface({
-        name, description, type, driver, mac, virtual: false, link, addresses
+        name, description, type, driver, mac, virtual: false, link, addresses, managed
     });
 };
 

--- a/src/lib/wicked/utils.js
+++ b/src/lib/wicked/utils.js
@@ -25,8 +25,12 @@ const PROPERTY_TO_TYPE = {
     bond: interfaceType.BONDING,
     bonding: interfaceType.BONDING,
     bridge: interfaceType.BRIDGE,
+    dummy: interfaceType.DUMMY,
     vlan: interfaceType.VLAN,
+    vxlan: interfaceType.VXLAN,
     wireless: interfaceType.WIRELESS,
+    gre: interfaceType.GRE,
+    sit: interfaceType.SIT,
     tun: interfaceType.TUN,
     tap: interfaceType.TAP,
 };

--- a/src/lib/wicked/utils.js
+++ b/src/lib/wicked/utils.js
@@ -26,7 +26,9 @@ const PROPERTY_TO_TYPE = {
     bonding: interfaceType.BONDING,
     bridge: interfaceType.BRIDGE,
     vlan: interfaceType.VLAN,
-    wireless: interfaceType.WIRELESS
+    wireless: interfaceType.WIRELESS,
+    tun: interfaceType.TUN,
+    tap: interfaceType.TAP,
 };
 
 /**

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -26,7 +26,7 @@ import { NetworkProvider } from '../src/context/network';
 const fs = require('fs');
 const path = require('path');
 
-export const customRender = (ui, { providerProps, ...renderOptions }) => {
+export const customRender = (ui, { providerProps, ...renderOptions } = {}) => {
     return render(
         <NetworkProvider {...providerProps}>{ui}</NetworkProvider>,
         renderOptions


### PR DESCRIPTION
## Problem

Currently we rely on `wicked show-xml` and `wicked show-config` in order to obtain the configuration and information of our system interfaces. There are configured interfaces that are not managed by wicked and the user should not be allowed to configure them.

- https://trello.com/c/aKfuut8E/2176-2-cockpit-wicked-do-not-allow-configuring-interfaces-that-are-not-handled-by-wicked

## Solution

- By now, all the interfaces with a `client-state` section will be treated as managed by wicked. Only the virtual ones without a `client-state` section will be omitted at all.