### PR TITLE
Adjust the label for the delete connection button

### DIFF
--- a/src/components/DeleteConnection.js
+++ b/src/components/DeleteConnection.js
@@ -36,9 +36,11 @@ const DeleteConnection = ({ connection, deleteConnection }) => {
         onClose();
     };
 
+    const deleteLabel = connection.virtual ? _("Delete") : _("Reset");
+
     return (
         <>
-            <Button variant="danger" className="pf-m-danger" onClick={() => setConfirmationOpen(true)}>{_("Reset")}</Button>
+            <Button variant="danger" className="pf-m-danger" onClick={() => setConfirmationOpen(true)}>{deleteLabel}</Button>
             { isConfirmationOpen &&
                 <ModalConfirm
                     title={cockpit.format(_("Delete '$0' configuration"), connection?.name)}


### PR DESCRIPTION
 Make clear when you are deleting or resetting (removing the configuration) an interface. We might think about using "Unconfigure" or "Remove configuration" (too long) instead of "Reset". @teclator @dgdavid What do you think?