### PR TITLE
Sets the new virtual interface as managed when it is added

### DIFF
--- a/src/context/reducers.js
+++ b/src/context/reducers.js
@@ -85,7 +85,7 @@ export function interfacesReducer(state, action) {
         let iface = Object.values(state).find((i) => i.name === conn.name);
 
         // or just adding a new one?
-        iface ||= createInterface({ name: conn.name, type: conn.type });
+        iface ||= createInterface({ name: conn.name, type: conn.type, managed: true });
 
         return {
             ...state,


### PR DESCRIPTION
## Problem

When a new **Bridge** / **Bond** or **Vlan** is configured, the new virtual interface appears during a moment as `unmanaged`. 

## Solution

When a new connection is added, in case that a new virtual interface is created, then it is initialized as managed.