### PR TITLE
Do not change the 'managed' property in Wicked

### DIFF
--- a/src/lib/wicked/adapter.js
+++ b/src/lib/wicked/adapter.js
@@ -96,7 +96,10 @@ class WickedAdapter {
     onInterfaceChange(fn) {
         this.client.onInterfaceChange((signal, iface) => {
             const data = (signal === 'deviceDelete') ? { ...iface, link: false } : iface;
-            fn(signal, createInterface(data));
+            // Do not trust in the calculated managed value. When changing an interface
+            // status the `client_state` element might be missing.
+            const { managed, ...newIface } = createInterface(data);
+            fn(signal, newIface);
         });
     }
 


### PR DESCRIPTION
It looks like, when the interface is being updated, the `client-state` section might be missing. It makes the interface to go to the *Unmanaged Interfaces* list, which is wrong. By now, let's ignore those changes in the update interface callback.

Related to #100 and #105.