### PR TITLE
Fix WickedAdapter#updateRoutes

### DIFF
--- a/src/lib/NetworkClient.js
+++ b/src/lib/NetworkClient.js
@@ -136,7 +136,7 @@ class NetworkClient {
     /**
      * Update routes
      *
-     * @param {Array<Object>} connections - List of routes to update
+     * @param {Array<Object>} routes - List of routes to update
      * @returns {Promise<Array|Error>} Resolves to an array of connection objects in case of success
      */
     async updateRoutes(routes) {

--- a/src/lib/wicked/adapter.js
+++ b/src/lib/wicked/adapter.js
@@ -227,23 +227,23 @@ class WickedAdapter {
 
         // Include all known interfaces to ensure successful deletions
         const ifaces = await this.interfaces();
-        const routesByDevice = ifaces.reduce((result, iface) => {
-            result[iface.name] = [];
-            return result;
-        }, {});
+        const ifacesNames = ifaces.map(i => i.name);
+        const keys = [NO_DEVICE_KEY, ...ifacesNames];
+        const routesByDevice = Object.fromEntries(keys.map(k => [k, []]));
 
         // Collect routes by device
         Object.values(routes).forEach((route) => {
-            const key = route.device || NO_DEVICE_KEY;
-            routesByDevice[key] ||= [];
-            routesByDevice[key].push(route);
+            const device = route.device || NO_DEVICE_KEY;
+            // It could be possible to receive routes for an unknown interface
+            routesByDevice[device] ||= [];
+            routesByDevice[device].push(route);
         });
 
         // Write route files
         const promises = [];
         Object.keys(routesByDevice)
                 .forEach(k => {
-                    const device = k !== NO_DEVICE_KEY ? k : undefined;
+                    const device = k === NO_DEVICE_KEY ? undefined : k;
                     const promise = new IfrouteFile(device).update(routesByDevice[k]);
                     promises.push(promise);
                 });

--- a/src/lib/wicked/adapter.js
+++ b/src/lib/wicked/adapter.js
@@ -219,13 +219,13 @@ class WickedAdapter {
     /**
      * Update route files
      *
-     * @param {Array} routes - routes to update
+     * @param {Object.<string|number, module/model/routes~Route} routes - routes to update
      * @return {Promise<Connection,Error>} Promise that resolve to the added connection
      */
     async updateRoutes(routes) {
         const NO_DEVICE_KEY = "none";
 
-        // Include all knows interface to ensure successful deletions
+        // Include all known interfaces to ensure successful deletions
         const ifaces = await this.interfaces();
         const routesByDevice = ifaces.reduce((result, iface) => {
             result[iface.name] = [];

--- a/src/lib/wicked/adapter.test.js
+++ b/src/lib/wicked/adapter.test.js
@@ -258,60 +258,60 @@ describe('#reloadConnection', () => {
 
         await expect(adapter.reloadConnection('eth0')).rejects.toEqual(error);
     });
+});
 
-    describe('#dnsSettings', () => {
-        const client = new Client();
-        const adapter = new Adapter(client);
+describe('#dnsSettings', () => {
+    const client = new Client();
+    const adapter = new Adapter(client);
 
-        const dnsSettings = {
-            NETCONFIG_DNS_POLICY: 'auto',
-            NETCONFIG_DNS_STATIC_SERVERS: '8.8.8.8',
-            NETCONFIG_DNS_STATIC_SEARCHLIST: 'suse.com'
-        };
+    const dnsSettings = {
+        NETCONFIG_DNS_POLICY: 'auto',
+        NETCONFIG_DNS_STATIC_SERVERS: '8.8.8.8',
+        NETCONFIG_DNS_STATIC_SEARCHLIST: 'suse.com'
+    };
 
-        const setKeyMock = jest.fn();
+    const setKeyMock = jest.fn();
 
-        beforeAll(() => {
-            SysconfigFile.mockImplementation(() => {
-                return {
-                    read: () => Promise.resolve(),
-                    write: () => Promise.resolve(),
-                    getKey: (key) => {
-                        return dnsSettings[key];
-                    },
-                    setKey: setKeyMock
-                };
-            });
+    beforeAll(() => {
+        SysconfigFile.mockImplementation(() => {
+            return {
+                read: () => Promise.resolve(),
+                write: () => Promise.resolve(),
+                getKey: (key) => {
+                    return dnsSettings[key];
+                },
+                setKey: setKeyMock
+            };
+        });
+    });
+
+    afterEach(() => {
+        SysconfigFile.mockClear();
+    });
+
+    it('returns the DNS settings', async () => {
+        expect(await adapter.dnsSettings()).toEqual({
+            policy: 'auto',
+            nameServers: ['8.8.8.8'],
+            searchList: ['suse.com']
+        });
+    });
+
+    it('writes the DNS settings', async () => {
+        await adapter.updateDnsSettings({
+            policy: 'auto',
+            nameServers: ['8.8.8.8', '1.1.1.1'],
+            searchList: ['suse.com', 'suse.de']
         });
 
-        afterEach(() => {
-            SysconfigFile.mockClear();
-        });
-
-        it('returns the DNS settings', async () => {
-            expect(await adapter.dnsSettings()).toEqual({
-                policy: 'auto',
-                nameServers: ['8.8.8.8'],
-                searchList: ['suse.com']
-            });
-        });
-
-        it('writes the DNS settings', async () => {
-            await adapter.updateDnsSettings({
-                policy: 'auto',
-                nameServers: ['8.8.8.8', '1.1.1.1'],
-                searchList: ['suse.com', 'suse.de']
-            });
-
-            expect(setKeyMock).toHaveBeenCalledWith(
-                'NETCONFIG_DNS_POLICY', 'auto'
-            );
-            expect(setKeyMock).toHaveBeenCalledWith(
-                'NETCONFIG_DNS_STATIC_SERVERS', '8.8.8.8 1.1.1.1')
-            ;
-            expect(setKeyMock).toHaveBeenCalledWith(
-                'NETCONFIG_DNS_STATIC_SEARCHLIST', 'suse.com suse.de'
-            );
-        });
+        expect(setKeyMock).toHaveBeenCalledWith(
+            'NETCONFIG_DNS_POLICY', 'auto'
+        );
+        expect(setKeyMock).toHaveBeenCalledWith(
+            'NETCONFIG_DNS_STATIC_SERVERS', '8.8.8.8 1.1.1.1')
+        ;
+        expect(setKeyMock).toHaveBeenCalledWith(
+            'NETCONFIG_DNS_STATIC_SEARCHLIST', 'suse.com suse.de'
+        );
     });
 });

--- a/src/lib/wicked/adapter.test.js
+++ b/src/lib/wicked/adapter.test.js
@@ -95,12 +95,6 @@ describe('#interfaces', () => {
     const configurations = [eth0_conn, br1_conn];
     const interfaces = [eth0_iface];
 
-    const resolveTo = (result) => () => {
-        return new Promise((resolve) => {
-            process.nextTick(() => resolve(result));
-        });
-    };
-
     beforeAll(() => {
         Client.mockImplementation(() => {
             return {


### PR DESCRIPTION

> Related to commit 855b80d, it ensures a proper deletion of
> /etc/sysconfig/network/routes file when there are no more routes without
> an associated interface.
> 
> Fixes #110.