### PR TITLE
Add an EmptyState when routes were not found

### DIFF
--- a/src/components/AddRoute.js
+++ b/src/components/AddRoute.js
@@ -26,13 +26,13 @@ import cockpit from 'cockpit';
 
 const _ = cockpit.gettext;
 
-const AddRoute = () => {
+const AddRoute = ({ variant = 'control' }) => {
     const [isFormOpen, setFormOpen] = useState(false);
 
     return (
         <>
-            <Button variant="control" onClick={() => setFormOpen(true)}>{_("Add Route")}</Button>
             { isFormOpen && <RouteForm isOpen={isFormOpen} onClose={() => setFormOpen(false)} /> }
+            <Button variant={variant} onClick={() => setFormOpen(true)}>{_("Add Route")}</Button>
         </>
     );
 };

--- a/src/components/RoutingTab.js
+++ b/src/components/RoutingTab.js
@@ -19,11 +19,23 @@
  * find current contact information at www.suse.com.
  */
 
+import cockpit from 'cockpit';
 import React, { useEffect } from 'react';
 import { useNetworkDispatch, useNetworkState, fetchRoutes } from '../context/network';
-import { Card, CardActions, CardBody, CardHeader } from '@patternfly/react-core';
+import {
+    Card,
+    CardActions,
+    CardBody,
+    CardHeader,
+    EmptyState,
+    EmptyStateIcon,
+    Title
+} from '@patternfly/react-core';
+import InfoCircleIcon from '@patternfly/react-icons/dist/js/icons/info-circle-icon';
 import RoutesList from './RoutesList';
 import AddRoute from './AddRoute';
+
+const _ = cockpit.gettext;
 
 const RoutingTab = () => {
     const dispatch = useNetworkDispatch();
@@ -32,6 +44,20 @@ const RoutingTab = () => {
     useEffect(() => { fetchRoutes(dispatch) }, [dispatch]);
 
     const routesList = routes ? Object.values(routes) : [];
+
+    const routesNotFound = () => (
+        <EmptyState>
+            <EmptyStateIcon icon={InfoCircleIcon} />
+            <Title headingLevel="h4" size="lg">
+                {_('No routes were found.')}
+            </Title>
+            <AddRoute variant="primary" />
+        </EmptyState>
+    );
+
+    if (routesList.length === 0) {
+        return routesNotFound();
+    }
 
     return (
         <Card>

--- a/src/components/RoutingTab.js
+++ b/src/components/RoutingTab.js
@@ -49,7 +49,7 @@ const RoutingTab = () => {
         <EmptyState>
             <EmptyStateIcon icon={InfoCircleIcon} />
             <Title headingLevel="h4" size="lg">
-                {_('No routes were found.')}
+                {_('No routes found.')}
             </Title>
             <AddRoute variant="primary" />
         </EmptyState>

--- a/src/components/RoutingTab.test.js
+++ b/src/components/RoutingTab.test.js
@@ -33,8 +33,7 @@ import NetworkClient from '../lib/NetworkClient';
 jest.mock('../lib/NetworkClient');
 
 describe('RoutingTab', () => {
-    const route0 = createRoute({ destination: '192.168.2.0/24', gateway: '192.168.2.1' });
-    const getRoutesMock = jest.fn(() => Promise.resolve([route0]));
+    const getRoutesMock = jest.fn();
 
     beforeAll(() => {
         resetClient();
@@ -46,54 +45,79 @@ describe('RoutingTab', () => {
         });
     });
 
-    test('list routes', async() => {
-        act(() => {
-            customRender(<RoutingTab />, { value: { routes: [] } });
+    describe('when routes were not found', () => {
+        beforeAll(() => {
+            getRoutesMock.mockImplementation(() => Promise.resolve([]));
         });
 
-        expect(await screen.findByRole('row', { name: '192.168.2.0/24 192.168.2.1' })).toBeInTheDocument();
+        test('display a message', async() => {
+            act(() => { customRender(<RoutingTab />) });
+
+            const result = await screen.findByText(/No routes were found/i);
+            expect(result).toBeInTheDocument();
+        });
+
+        test('add a route', async() => {
+            act(() => { customRender(<RoutingTab />) });
+
+            userEvent.click(screen.getByRole('button', { name: 'Add Route' }));
+
+            expect(await screen.findByRole('dialog')).toBeInTheDocument();
+            const dialog = screen.getByRole('dialog');
+            userEvent.type(getByLabelText(dialog, /gateway/i), '192.168.1.1');
+            userEvent.type(getByLabelText(dialog, /destination/i), '192.168.1.0/24');
+            userEvent.click(screen.getByRole('button', { name: 'Add' }));
+            expect(await screen.findByText('192.168.1.1')).toBeInTheDocument();
+        });
     });
 
-    test('add a route', async() => {
-        act(() => {
-            customRender(<RoutingTab />, { value: { routes: [] } });
+    describe('when routes were found', () => {
+        beforeAll(() => {
+            const route0 = createRoute({ destination: '192.168.2.0/24', gateway: '192.168.2.1' });
+            getRoutesMock.mockImplementation(() => Promise.resolve([route0]));
         });
 
-        expect(await screen.findByText('192.168.2.1')).toBeInTheDocument();
-        userEvent.click(screen.getByRole('button', { name: 'Add Route' }));
+        test('list routes', async() => {
+            act(() => { customRender(<RoutingTab />) });
 
-        expect(await screen.findByRole('dialog')).toBeInTheDocument();
-        const dialog = screen.getByRole('dialog');
-        userEvent.type(getByLabelText(dialog, /gateway/i), '192.168.1.1');
-        userEvent.type(getByLabelText(dialog, /destination/i), '192.168.1.0/24');
-        userEvent.click(screen.getByRole('button', { name: 'Add' }));
-        expect(await screen.findByText('192.168.1.1')).toBeInTheDocument();
-    });
-
-    test('modify a route', async() => {
-        act(() => {
-            customRender(<RoutingTab />, { value: { routes: [] } });
+            expect(await screen.findByRole('row', { name: '192.168.2.0/24 192.168.2.1' })).toBeInTheDocument();
         });
 
-        expect(await screen.findByText('192.168.2.1')).toBeInTheDocument();
-        userEvent.click(screen.getByRole('button', { name: 'Actions' }));
-        userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+        test('add a route', async() => {
+            act(() => { customRender(<RoutingTab />) });
 
-        expect(await screen.findByRole('dialog')).toBeInTheDocument();
-        const dialog = screen.getByRole('dialog');
-        userEvent.type(getByLabelText(dialog, /gateway/i), '{backspace}2');
-        userEvent.click(screen.getByRole('button', { name: 'Change' }));
-        expect(await screen.findByText('192.168.2.2')).toBeInTheDocument();
-    });
+            expect(await screen.findByText('192.168.2.1')).toBeInTheDocument();
+            userEvent.click(screen.getByRole('button', { name: 'Add Route' }));
 
-    test('removes a route', async() => {
-        act(() => {
-            customRender(<RoutingTab />, { value: { routes: [] } });
+            expect(await screen.findByRole('dialog')).toBeInTheDocument();
+            const dialog = screen.getByRole('dialog');
+            userEvent.type(getByLabelText(dialog, /gateway/i), '192.168.1.1');
+            userEvent.type(getByLabelText(dialog, /destination/i), '192.168.1.0/24');
+            userEvent.click(screen.getByRole('button', { name: 'Add' }));
+            expect(await screen.findByText('192.168.1.1')).toBeInTheDocument();
         });
 
-        expect(await screen.findByText('192.168.2.1')).toBeInTheDocument();
-        userEvent.click(screen.getByRole('button', { name: 'Actions' }));
-        userEvent.click(screen.getByRole('button', { name: 'Delete' }));
-        expect(screen.queryByText('192.168.2.1')).toBeNull();
+        test('modify a route', async() => {
+            act(() => { customRender(<RoutingTab />) });
+
+            expect(await screen.findByText('192.168.2.1')).toBeInTheDocument();
+            userEvent.click(screen.getByRole('button', { name: 'Actions' }));
+            userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+            expect(await screen.findByRole('dialog')).toBeInTheDocument();
+            const dialog = screen.getByRole('dialog');
+            userEvent.type(getByLabelText(dialog, /gateway/i), '{backspace}2');
+            userEvent.click(screen.getByRole('button', { name: 'Change' }));
+            expect(await screen.findByText('192.168.2.2')).toBeInTheDocument();
+        });
+
+        test('removes a route', async() => {
+            act(() => { customRender(<RoutingTab />) });
+
+            expect(await screen.findByText('192.168.2.1')).toBeInTheDocument();
+            userEvent.click(screen.getByRole('button', { name: 'Actions' }));
+            userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+            expect(screen.queryByText('192.168.2.1')).toBeNull();
+        });
     });
 });

--- a/src/components/RoutingTab.test.js
+++ b/src/components/RoutingTab.test.js
@@ -53,7 +53,7 @@ describe('RoutingTab', () => {
         test('display a message', async() => {
             act(() => { customRender(<RoutingTab />) });
 
-            const result = await screen.findByText(/No routes were found/i);
+            const result = await screen.findByText(/No routes found/i);
             expect(result).toBeInTheDocument();
         });
 


### PR DESCRIPTION
As agreed in https://github.com/openSUSE/cockpit-wicked/pull/111#issuecomment-738081804.

| Before | After |
| - | - |
| ![No routes w/o empty state](https://user-images.githubusercontent.com/1691872/101058784-6ff23980-3585-11eb-848d-83efe52772fc.png) | ![No routes empty state](https://user-images.githubusercontent.com/1691872/101059266-fb6bca80-3585-11eb-822f-5e58609ef8e0.png) |

