### PR TITLE
Consider a virtual interface as managed only when there is an origin config

### DIFF
--- a/src/lib/wicked/interfaces.js
+++ b/src/lib/wicked/interfaces.js
@@ -51,7 +51,7 @@ const createInterface = (iface) => {
 
     const addresses = (assignedAddresses || []).map(model.createAddressConfig);
 
-    const managed = !!client_state?.config;
+    const managed = !!client_state?.config?.origin;
 
     return model.createInterface({
         name, description, type, driver, mac, virtual: false, link, addresses, managed

--- a/src/lib/wicked/interfaces.test.js
+++ b/src/lib/wicked/interfaces.test.js
@@ -28,7 +28,10 @@ describe('#createInterface', () => {
             addresses: [
                 { local: '192.168.1.101/24', broadcast: '192.168.1.155' },
                 { local: 'fe80::3091:4019:f740:9b97/64' }
-            ]
+            ],
+            client_state: {
+                config: { origin: 'suse:compat:/etc/sysconfig/network/ifcfg-eth0' }
+            }
         },
         ethtool: {
             driver_info: { driver: 'virtio_net' },
@@ -48,8 +51,38 @@ describe('#createInterface', () => {
             description: '',
             type: 'eth',
             virtual: false,
-            link: false
+            link: false,
+            managed: true
         }));
+    });
+
+    describe('when no origin is reported', () => {
+        const wickedInterface = {
+            interface: {
+                name: 'eth0',
+                client_state: {
+                    config: { origin: '' }
+                }
+            }
+        };
+
+        it('sets "managed" to false', () => {
+            const iface = createInterface(wickedInterface);
+            expect(iface.managed).toEqual(false);
+        });
+    });
+
+    describe('when no client state is reported', () => {
+        const wickedInterface = {
+            interface: {
+                name: 'eth0',
+            }
+        };
+
+        it('sets "managed" to false', () => {
+            const iface = createInterface(wickedInterface);
+            expect(iface.managed).toEqual(false);
+        });
     });
 
     it('includes the assigned addresses', () => {


### PR DESCRIPTION
## Problem

Checking the `client-state -> config` section could be wrong as there are some scenarios which will show the interfaces as managed by wicked although them are managed by a third party tool like when switching from **NetworkManager** to **wicked**.

## Solution

We will check that the virtual interfaces have a origin config in order to consider them managed by wicked

## Todo

- [x] Unit tests