### PR TITLE
Improve UX (related to actions)

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -123,10 +123,6 @@ p {
             width: var(--pf-global--spacer--lg);
             text-align: center;
         }
-
-        .actions-column {
-            text-align: right;
-        }
     }
 
     tbody tr:hover {

--- a/src/app.scss
+++ b/src/app.scss
@@ -147,6 +147,10 @@ p {
 .pf-c-switch.interface-status-switcher {
    --pf-c-switch--FontSize: var(--pf-global--FontSize--sm);
    vertical-align: text-bottom;
+
+   .pf-c-switch__label {
+     padding-left: calc(var(--pf-global--FontSize--sm) / 2);
+   }
 }
 
 .pf-c-button.pf-m-link.delete-action {

--- a/src/app.scss
+++ b/src/app.scss
@@ -144,15 +144,15 @@ p {
     }
 }
 
-.pf-c-dropdown__menu-item.dangerous-action {
-  button.pf-m-link {
-    color: var(--pf-global--danger-color--200);
-  }
+.pf-c-switch.interface-status-switcher {
+   --pf-c-switch--FontSize: var(--pf-global--FontSize--sm);
+   vertical-align: text-bottom;
+}
+
+.pf-c-button.pf-m-link.delete-action {
+  color: var(--pf-global--Color--200);
 
   &:hover {
-    background-color: var(--pf-global--danger-color--200);
-    button.pf-m-link {
-      color: white;
-    }
+    color: var(--pf-global--danger-color--200);
   }
 }

--- a/src/components/InterfaceActions.js
+++ b/src/components/InterfaceActions.js
@@ -50,17 +50,27 @@ const InterfaceActions = ({ iface, connection }) => {
         deleteConnection(dispatch, connection);
         closeDeleteConfirmation();
     };
+
     const renderDeleteConfirmation = () => {
         if (!showDeleteConfirmation) return null;
 
+        const confirmationTitle = cockpit.format(
+            _("$action '$iface' configuration"),
+            { action: deleteTooltip, iface: connection?.name }
+        );
+        const confirmationMessage = cockpit.format(
+            _("Please, confirm that you really want to $action the interface configuration."),
+            { action:  deleteTooltip.toLowerCase() }
+        );
+
         return (
             <ModalConfirm
-                title={cockpit.format(_("Delete '$0' configuration"), connection?.name)}
+                title={confirmationTitle}
                 isOpen={showDeleteConfirmation}
                 onCancel={closeDeleteConfirmation}
                 onConfirm={onDeleteConfirmation}
             >
-                {_("Please, confirm that you really want to the delete the interface configuration.")}
+                {confirmationMessage}
             </ModalConfirm>
         );
     };

--- a/src/components/InterfaceActions.js
+++ b/src/components/InterfaceActions.js
@@ -39,7 +39,13 @@ const InterfaceActions = ({ iface, connection }) => {
 
     const DeleteIcon = connection.virtual ? TrashIcon : ResetIcon;
     const deleteTooltip = connection.virtual ? _("Delete") : _("Reset");
-    const changeStatusTooltip = iface.link ? _("Disable") : _("Enable");
+    const changeStatusLabel = _("Enable");
+    const changeStatusLabelOff = _("Disable");
+    const changeStatusAction = iface.link ? changeStatusLabelOff : changeStatusLabel;
+    const changeStatusTooltip = cockpit.format(
+        _("Click to $action it"),
+        { action: changeStatusAction.toLowerCase() }
+    );
     const openDeleteConfirmation = () => setShowDeleteConfirmation(true);
     const closeDeleteConfirmation = () => setShowDeleteConfirmation(false);
     const onDeleteConfirmation = () => {
@@ -96,7 +102,9 @@ const InterfaceActions = ({ iface, connection }) => {
             <Tooltip content={changeStatusTooltip}>
                 <Switch
                     id={`${iface.name}-status-switcher}`}
-                    aria-label={`${changeStatusTooltip} ${iface.name}`}
+                    aria-label={`${changeStatusAction} ${iface.name}`}
+                    label={changeStatusLabel}
+                    labelOff={changeStatusLabelOff}
                     className="interface-status-switcher"
                     isChecked={iface.link}
                     onChange={() => changeConnectionState(dispatch, connection, !iface.link)}

--- a/src/components/InterfaceActions.js
+++ b/src/components/InterfaceActions.js
@@ -23,13 +23,13 @@ import cockpit from "cockpit";
 import React, { useState } from 'react';
 import {
     Button,
-    Dropdown,
-    DropdownItem,
-    DropdownPosition,
-    KebabToggle
+    Switch,
+    Tooltip
 } from '@patternfly/react-core';
 import { useNetworkDispatch, deleteConnection, changeConnectionState } from '../context/network';
 import ModalConfirm from './ModalConfirm';
+import TrashIcon from '@patternfly/react-icons/dist/js/icons/trash-icon';
+import ResetIcon from '@patternfly/react-icons/dist/js/icons/undo-icon';
 
 const _ = cockpit.gettext;
 
@@ -41,7 +41,9 @@ const InterfaceActions = ({ iface, connection }) => {
     const onToggle = isOpen => setIsOpen(isOpen);
     const onSelect = (event) => onToggle(!isOpen);
 
-    const deleteActionLabel = connection.virtual ? _("Delete") : _("Reset");
+    const DeleteIcon = connection.virtual ? TrashIcon : ResetIcon;
+    const deleteTooltip = connection.virtual ? _("Delete") : _("Reset");
+    const changeStatusTooltip = iface.link ? _("Disable") : _("Enable");
     const openDeleteConfirmation = () => setShowDeleteConfirmation(true);
     const closeDeleteConfirmation = () => setShowDeleteConfirmation(false);
     const onDeleteConfirmation = () => {
@@ -63,32 +65,27 @@ const InterfaceActions = ({ iface, connection }) => {
         );
     };
 
-    const actions = [
-        <DropdownItem key={`${iface.name}-change-state`}>
-            <Button
-                variant="link"
-                onClick={() => changeConnectionState(dispatch, connection, !iface.link)}
-            >
-                {iface.link ? _("Disable") : _("Enable")}
-            </Button>
-        </DropdownItem>,
-        <DropdownItem key={`${iface.name}-reset-connection`} className="dangerous-action">
-            <Button variant="link" onClick={openDeleteConfirmation}>
-                {deleteActionLabel}
-            </Button>
-        </DropdownItem>
-    ];
-
     return (
         <>
-            <Dropdown
-                isPlain
-                position={DropdownPosition.right}
-                isOpen={isOpen}
-                onSelect={onSelect}
-                dropdownItems={actions}
-                toggle={<KebabToggle id={`connection-${connection.id}-actions`} onToggle={onToggle} />}
-            />
+            <Tooltip content={changeStatusTooltip}>
+                <Switch
+                    id={`${iface.name}-status-switcher}`}
+                    aria-label={`${changeStatusTooltip} ${iface.name}`}
+                    className="interface-status-switcher"
+                    isChecked={iface.link}
+                    onChange={() => changeConnectionState(dispatch, connection, !iface.link)}
+                />
+            </Tooltip>
+            <Tooltip content={deleteTooltip}>
+                <Button
+                    variant="link"
+                    aria-label={`${deleteTooltip} ${iface.name}`}
+                    className="delete-action"
+                    onClick={openDeleteConfirmation}
+                >
+                    <DeleteIcon />
+                </Button>
+            </Tooltip>
             { renderDeleteConfirmation() }
         </>
     );

--- a/src/components/InterfaceActions.js
+++ b/src/components/InterfaceActions.js
@@ -75,6 +75,26 @@ const InterfaceActions = ({ iface, connection }) => {
         );
     };
 
+    const renderDeleteAction = () => {
+        if (!connection.exists) return null;
+
+        return (
+            <>
+                <Tooltip content={deleteTooltip}>
+                    <Button
+                        variant="link"
+                        aria-label={`${deleteTooltip} ${iface.name}`}
+                        className="delete-action"
+                        onClick={openDeleteConfirmation}
+                    >
+                        <DeleteIcon />
+                    </Button>
+                </Tooltip>
+                { renderDeleteConfirmation() }
+            </>
+        );
+    };
+
     return (
         <>
             <Tooltip content={changeStatusTooltip}>
@@ -86,17 +106,7 @@ const InterfaceActions = ({ iface, connection }) => {
                     onChange={() => changeConnectionState(dispatch, connection, !iface.link)}
                 />
             </Tooltip>
-            <Tooltip content={deleteTooltip}>
-                <Button
-                    variant="link"
-                    aria-label={`${deleteTooltip} ${iface.name}`}
-                    className="delete-action"
-                    onClick={openDeleteConfirmation}
-                >
-                    <DeleteIcon />
-                </Button>
-            </Tooltip>
-            { renderDeleteConfirmation() }
+            { renderDeleteAction() }
         </>
     );
 };

--- a/src/components/InterfaceActions.js
+++ b/src/components/InterfaceActions.js
@@ -34,12 +34,8 @@ import ResetIcon from '@patternfly/react-icons/dist/js/icons/undo-icon';
 const _ = cockpit.gettext;
 
 const InterfaceActions = ({ iface, connection }) => {
-    const [isOpen, setIsOpen] = useState(false);
     const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
     const dispatch = useNetworkDispatch();
-
-    const onToggle = isOpen => setIsOpen(isOpen);
-    const onSelect = (event) => onToggle(!isOpen);
 
     const DeleteIcon = connection.virtual ? TrashIcon : ResetIcon;
     const deleteTooltip = connection.virtual ? _("Delete") : _("Reset");

--- a/src/components/InterfaceActions.test.js
+++ b/src/components/InterfaceActions.test.js
@@ -48,10 +48,7 @@ describe('InterfaceActions', () => {
                 <InterfaceActions iface={iface} connection={connection} />
             );
 
-            const actionsButton = screen.getByLabelText('Actions');
-            userEvent.click(actionsButton);
-
-            expect(screen.getByText('Disable')).toBeInTheDocument();
+            expect(screen.getByLabelText('Disable eth0')).toBeInTheDocument();
         });
 
         test('includes an action to reset it', () => {
@@ -59,10 +56,7 @@ describe('InterfaceActions', () => {
                 <InterfaceActions iface={iface} connection={connection} />
             );
 
-            const actionsButton = screen.getByLabelText('Actions');
-            userEvent.click(actionsButton);
-
-            expect(screen.getByText('Reset')).toBeInTheDocument();
+            expect(screen.getByLabelText('Reset eth0')).toBeInTheDocument();
         });
     });
 
@@ -80,10 +74,7 @@ describe('InterfaceActions', () => {
                 <InterfaceActions iface={iface} connection={connection} />
             );
 
-            const actionsButton = screen.getByLabelText('Actions');
-            userEvent.click(actionsButton);
-
-            expect(screen.getByText('Enable')).toBeInTheDocument();
+            expect(screen.getByLabelText('Enable eth0')).toBeInTheDocument();
         });
 
         test('includes an action to reset it', () => {
@@ -91,39 +82,11 @@ describe('InterfaceActions', () => {
                 <InterfaceActions iface={iface} connection={connection} />
             );
 
-            const actionsButton = screen.getByLabelText('Actions');
-            userEvent.click(actionsButton);
-
-            expect(screen.getByText('Reset')).toBeInTheDocument();
+            expect(screen.getByLabelText('Reset eth0')).toBeInTheDocument();
         });
     });
 
-    describe('when triggering an action', () => {
-        const iface = createInterface(
-            {
-                name: 'eth0',
-                mac: '00:d8:23:93:14:cc',
-                addresses: [createAddressConfig({ local: '192.168.8.100/24' })]
-            }
-        );
-
-        test('hides actions menu', () => {
-            customRender(
-                <InterfaceActions iface={iface} connection={connection} />
-            );
-
-            const actionsButton = screen.getByLabelText('Actions');
-            userEvent.click(actionsButton);
-
-            const availableActions = screen.getByRole('menu');
-            expect(availableActions).toBeVisible();
-
-            userEvent.click(screen.getByText('Reset'));
-            expect(availableActions).not.toBeInTheDocument();
-        });
-    });
-
-    describe('when Reset action is triggered', () => {
+    describe('when delete/reset action is triggered', () => {
         const iface = createInterface(
             {
                 name: 'eth0',
@@ -137,13 +100,11 @@ describe('InterfaceActions', () => {
                 <InterfaceActions iface={iface} connection={connection} />
             );
 
-            const actionsButton = screen.getByLabelText('Actions');
-            userEvent.click(actionsButton);
-
-            const resetAction = screen.getByText('Reset');
-            userEvent.click(resetAction);
+            const deleteAction = screen.getByLabelText('Reset eth0');
+            userEvent.click(deleteAction);
 
             expect(screen.getByRole('dialog')).toBeInTheDocument();
+            // Strings are being neither, formatted nor translated during tests. See __mocks__/cockpit.js
             expect(screen.getByText(/Delete .* configuration/, { selector:  'h1' })).toBeInTheDocument();
             expect(screen.getByText('Confirm', { selector: 'button' })).toBeInTheDocument();
         });

--- a/src/components/InterfaceActions.test.js
+++ b/src/components/InterfaceActions.test.js
@@ -105,7 +105,7 @@ describe('InterfaceActions', () => {
 
             expect(screen.getByRole('dialog')).toBeInTheDocument();
             // Strings are being neither, formatted nor translated during tests. See __mocks__/cockpit.js
-            expect(screen.getByText(/Delete .* configuration/, { selector:  'h1' })).toBeInTheDocument();
+            expect(screen.getByText(/\$action .* configuration/, { selector:  'h1' })).toBeInTheDocument();
             expect(screen.getByText('Confirm', { selector: 'button' })).toBeInTheDocument();
         });
     });

--- a/src/components/InterfaceDetails.js
+++ b/src/components/InterfaceDetails.js
@@ -28,7 +28,8 @@ import VlanDetails from './VlanDetails';
 import WirelessDetails from './WirelessDetails';
 import IPSettingsLink from './IPSettingsLink';
 import interfaceTypeEnum from '../lib/model/interfaceType';
-import { Alert } from '@patternfly/react-core';
+import { Alert, Split, SplitItem } from '@patternfly/react-core';
+import InterfaceActions from "./InterfaceActions";
 
 const _ = cockpit.gettext;
 
@@ -130,11 +131,18 @@ const InterfaceDetails = ({ iface, connection }) => {
         <>
             {renderError(iface.error)}
 
-            <dl className="details-list">
-                { iface.mac && macAddress(iface) }
-                {startMode(connection)}
-                {renderFullDetails()}
-            </dl>
+            <Split hasGutter>
+                <SplitItem isFilled>
+                    <dl className="details-list">
+                        { iface.mac && macAddress(iface) }
+                        {startMode(connection)}
+                        {renderFullDetails()}
+                    </dl>
+                </SplitItem>
+                <SplitItem>
+                    <InterfaceActions iface={iface} connection={connection} />
+                </SplitItem>
+            </Split>
         </>
     );
 };

--- a/src/components/InterfacesList.js
+++ b/src/components/InterfacesList.js
@@ -33,7 +33,6 @@ import {
 import { Spinner } from '@patternfly/react-core';
 import AlertIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import InterfaceDetails from "./InterfaceDetails";
-import InterfaceActions from "./InterfaceActions";
 import interfaceType from '../lib/model/interfaceType';
 import interfaceStatus from '../lib/model/interfaceStatus';
 import { createConnection } from '../lib/model/connections';
@@ -49,8 +48,7 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
         { title: _("Name"), cellFormatters: [expandable] },
         { title: _("Type") },
         { title: _("Status"), transforms: [cellWidth(10)], cellTransforms: [truncate] },
-        { title: _("Addresses") },
-        { title: "", props: { className: "actions-column" } }
+        { title: _("Addresses") }
     ];
 
     const interfaceAddresses = (iface) => {
@@ -111,8 +109,7 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
                         i.name,
                         interfaceType.label(i.type),
                         renderStatusText(i),
-                        interfaceAddresses(i),
-                        <><InterfaceActions iface={i} connection={conn} /></>
+                        interfaceAddresses(i)
                     ]
                 }
             );
@@ -123,7 +120,7 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
                         "",
                         {
                             title: <InterfaceDetails iface={i} connection={conn} />,
-                            props: { colSpan: 5 }
+                            props: { colSpan: 4 }
                         }
                     ]
                 }

--- a/src/components/InterfacesList.test.js
+++ b/src/components/InterfacesList.test.js
@@ -53,21 +53,6 @@ describe('InterfacesList', () => {
         expect(screen.getByText('192.168.8.100/24')).toBeInTheDocument();
     });
 
-    test('display actions', () => {
-        customRender(
-            <InterfacesList interfaces={interfaces} connections={connections} />
-        );
-
-        expect(screen.queryByText('Disable')).not.toBeInTheDocument();
-        expect(screen.queryByText('Reset')).not.toBeInTheDocument();
-
-        const actionsButton = screen.getByLabelText('Actions');
-        userEvent.click(actionsButton);
-
-        expect(screen.getByText('Disable')).toBeVisible();
-        expect(screen.getByText('Reset')).toBeVisible();
-    });
-
     test('display details', () => {
         customRender(
             <InterfacesList interfaces={interfaces} connections={connections} />
@@ -80,6 +65,21 @@ describe('InterfacesList', () => {
         userEvent.click(expandButton);
         expect(screen.getByText('00:d8:23:93:14:cc')).toBeVisible();
         expect(screen.getByText('On Boot')).toBeVisible();
+    });
+
+    test('include actions into details', () => {
+        customRender(
+            <InterfacesList interfaces={interfaces} connections={connections} />
+        );
+
+        expect(screen.getByLabelText('Disable eth0')).not.toBeVisible();
+        expect(screen.getByLabelText('Reset eth0')).not.toBeVisible();
+
+        const expandButton = screen.getByRole('button', { name: 'Details' });
+        userEvent.click(expandButton);
+
+        expect(screen.getByLabelText('Disable eth0')).toBeVisible();
+        expect(screen.getByLabelText('Reset eth0')).toBeVisible();
     });
 
     test('when the connection is not configured', () => {


### PR DESCRIPTION
Related to feedback received after changes introduced in #114

* Reintroduces the [`Switch`](https://www.patternfly.org/v4/components/switch) component for toggling the interface status (enabled/disabled), but using a label with the current status and a tooltip to explain what is going to happen after clicking on it.
  
  | Interface enabled | Interface disabled | Tooltip |
  |-|-|-|
  | ![Interface enabled](https://user-images.githubusercontent.com/1691872/103526262-918e5b80-4e78-11eb-834b-557b234e1101.png) | ![Interface disabled](https://user-images.githubusercontent.com/1691872/103526268-92bf8880-4e78-11eb-9a11-a0a519aa2b83.png) | ![Switch tooltip](https://user-images.githubusercontent.com/1691872/103526061-3197b500-4e78-11eb-90ee-b620181b4767.png) |

* Recovers the behavior of displaying the delete action only when the connection _exists_ (lost by mistake in #114, see https://github.com/openSUSE/cockpit-wicked/pull/114/files#diff-63e4e33667f33c59ceedc8457ed509037f008b4a34625217e523f676301b0b79L134-L137)

* Uses an icon for the reset/delete connection action, using a tooltip with the action

  | Reset connection Icon | Delete connection Icon |
  |-|-|
  | ![Reset connection icon](https://user-images.githubusercontent.com/1691872/103526559-0497d200-4e79-11eb-9c5a-e95fe162e994.png) | ![Delete connection icon](https://user-images.githubusercontent.com/1691872/103526732-4163c900-4e79-11eb-93b2-bbcc488bb4d3.png) |


* Moves those actions back to the interface's details, keeping the list a bit less crowded.

  ![Screenshot_2021-01-04 Networking - ytm 10 0 0 204](https://user-images.githubusercontent.com/1691872/103523300-900e6480-4e73-11eb-97dc-3704568ff9b4.png)


If not desired, the last change is easily undo-able.
