### PR TITLE
Fix interface status labels

### DIFF
--- a/src/components/InterfaceActions.js
+++ b/src/components/InterfaceActions.js
@@ -39,9 +39,9 @@ const InterfaceActions = ({ iface, connection }) => {
 
     const DeleteIcon = connection.virtual ? TrashIcon : ResetIcon;
     const deleteTooltip = connection.virtual ? _("Delete") : _("Reset");
-    const changeStatusLabel = _("Enable");
-    const changeStatusLabelOff = _("Disable");
-    const changeStatusAction = iface.link ? changeStatusLabelOff : changeStatusLabel;
+    const changeStatusLabel = _("Enabled");
+    const changeStatusLabelOff = _("Disabled");
+    const changeStatusAction = iface.link ? _("Disable") : _("Enable");
     const changeStatusTooltip = cockpit.format(
         _("Click to $action it"),
         { action: changeStatusAction.toLowerCase() }


### PR DESCRIPTION
Related to #115, changes `Enable` and `Disable` by `Enabled` and `Disabled`.

![Screenshot_2021-01-11 Networking - ytm 10 0 0 204](https://user-images.githubusercontent.com/1691872/104187609-f8c78500-540f-11eb-9780-b8bb8c9a2033.png)
