### PR TITLE
Fix device status tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.retry
 *.tar.gz
 *.rpm
+.log/
 node_modules/
 dist/
 /*.spec

--- a/src/lib/wicked/client.js
+++ b/src/lib/wicked/client.js
@@ -260,7 +260,8 @@ class WickedClient {
         });
 
         this._onSignal('deviceDelete', this._onDeviceDelete.bind(this));
-        this._onSignal(['deviceCreate', 'networkUp', 'linkUp', 'networkDown', 'linkDown', 'addressAcquired',
+        this._onSignal(['deviceCreate', 'networkUp', 'linkUp', 'networkDown',
+            'linkDown', 'deviceDown', 'addressAcquired', 'addressReleased',
             'deviceReady', 'deviceChange'], this._onDeviceEvent.bind(this));
 
         // TODO: de-bouncing.

--- a/src/lib/wicked/interfaces.js
+++ b/src/lib/wicked/interfaces.js
@@ -45,7 +45,7 @@ const createInterface = (iface) => {
 
     const ethtool = iface.ethtool || {};
     const { driver_info } = ethtool;
-    const link = status.split(", ").includes("device-up");
+    const link = status.split(", ").includes("link-up");
     const driver = driver_info?.driver;
 
     const mac = iface?.ethernet?.address;

--- a/src/lib/wicked/interfaces.test.js
+++ b/src/lib/wicked/interfaces.test.js
@@ -25,7 +25,7 @@ describe('#createInterface', () => {
     const wickedInterface = {
         interface: {
             name: 'eth0',
-            status: 'ready, device-up, arp, broadcast, multicast',
+            status: 'ready, device-up, link-up, arp, broadcast, multicast',
             addresses: [
                 { local: '192.168.1.101/24', broadcast: '192.168.1.155' },
                 { local: 'fe80::3091:4019:f740:9b97/64' }
@@ -57,6 +57,14 @@ describe('#createInterface', () => {
         }));
     });
 
+    it('includes the assigned addresses', () => {
+        const iface = createInterface(wickedInterface);
+        expect(iface.addresses).toEqual(expect.arrayContaining([
+            expect.objectContaining({ type: 'ipv4', local: '192.168.1.101/24' }),
+            expect.objectContaining({ type: "ipv6", local: 'fe80::3091:4019:f740:9b97/64' })
+        ]));
+    });
+
     describe('when no origin is reported', () => {
         const wickedInterface = {
             interface: {
@@ -86,11 +94,17 @@ describe('#createInterface', () => {
         });
     });
 
-    it('includes the assigned addresses', () => {
-        const iface = createInterface(wickedInterface);
-        expect(iface.addresses).toEqual(expect.arrayContaining([
-            expect.objectContaining({ type: 'ipv4', local: '192.168.1.101/24' }),
-            expect.objectContaining({ type: "ipv6", local: 'fe80::3091:4019:f740:9b97/64' })
-        ]));
+    describe('when link is down', () => {
+        const wickedInterface = {
+            interface: {
+                name: 'eth0',
+                status: 'ready, device-up, arp, broadcast, multicast'
+            }
+        };
+
+        it('sets "link" to false', () => {
+            const iface = createInterface(wickedInterface);
+            expect(iface.link).toEqual(false);
+        });
     });
 });


### PR DESCRIPTION
According to [bsc#1182189](https://bugzilla.suse.com/show_bug.cgi?id=1182189) and [bsc#1186736](https://bugzilla.suse.com/show_bug.cgi?id=1186736) there are a few problems when trying to determine the interface status. #123 was a step in the right direction, but it looks like relying on `device-up` was [not a good idea at all](https://bugzilla.suse.com/show_bug.cgi?id=1186736#c3).

This PR introduces these changes:

* Rely on `link-up` instead to set up the `link` value.
* Listen to `deviceDown` and `addressReleased` D-Bus events. The reason is that in some cases (like when unplugging the cable and running `ifdown` after that) causes Cockpit Wicked to consider that the addresses are still assigned.