### PR TITLE
Follow Cockpit project practice and remove 'version'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,10 @@
 {
   "name": "wicked",
-  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked",
-      "version": "4.0.0",
       "license": "GPL-2.0",
       "dependencies": {
         "@patternfly/patternfly": "4.50.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "wicked",
-  "version": "4.0.0",
   "description": "Cockpit user interface for wicked",
   "main": "index.js",
   "repository": "https://github.com/dgdavid/cockpit-wicked",


### PR DESCRIPTION
Although "name" and "version" are supposed [to be mandatory](https://docs.npmjs.com/creating-a-package-json-file), Cockpit Project does not set version numbers in `package.json`. After all, those packages are not published on [npm](https://npmjs.com/).