### PR TITLE
Fix wicked wireless configuration parser (bsc#1196528)

### DIFF
--- a/src/lib/wicked/client.js
+++ b/src/lib/wicked/client.js
@@ -176,7 +176,7 @@ class WickedClient {
         if (this._connections && cache) return this._connections;
 
         const stdout = await cockpit.spawn(['/usr/sbin/wicked', 'show-config']);
-        this._connections = XmlToJson(stdout, ['body', 'slaves', 'ipv4:static', 'ipv6:static', 'ports']);
+        this._connections = XmlToJson(stdout, ['body', 'slaves', 'ipv4:static', 'ipv6:static', 'ports', 'networks']);
         return this._connections;
     }
 

--- a/src/lib/wicked/connections.js
+++ b/src/lib/wicked/connections.js
@@ -178,6 +178,8 @@ const propsByWirelessAuthMode = {
     }
 };
 
+const networkFrom = (wireless) => wireless.networks ? wireless.networks[0] : wireless.network;
+
 const propsByConnectionType = {
     [interfaceType.BONDING]: ({ bond }) => {
         const { slaves = [], mode = bondingMode.ACTIVE_BACKUP, options = "", miimon = { frequency: "100" } } = bond;
@@ -194,17 +196,17 @@ const propsByConnectionType = {
         return { vlan: { parentDevice: device, vlanId: tag } };
     },
     [interfaceType.WIRELESS]: ({ wireless }) => {
-        const { ap_scan, network, networks } = wireless;
+        const { ap_scan } = wireless;
+        const first_network = networkFrom(wireless);
 
-        if (!network && !networks) return { wireless: { ap_scan } };
-
-        const first_network = network || networks[0];
-        const { essid, mode } = first_network;
+        if (!first_network) return { wireless: { ap_scan } };
         const authMode = wirelessAuthModeFor(first_network);
 
         return {
             wireless: {
-                ap_scan, essid, mode: wirelessModeFor(mode), authMode,
+                ap_scan, authMode,
+                essid: first_network.essid,
+                mode: wirelessModeFor(first_network.mode),
                 // FIXME: we should use and object instead of destructuring the props
                 ...propsByAuthMode(authMode, first_network)
             }

--- a/src/lib/wicked/connections.js
+++ b/src/lib/wicked/connections.js
@@ -194,15 +194,19 @@ const propsByConnectionType = {
         return { vlan: { parentDevice: device, vlanId: tag } };
     },
     [interfaceType.WIRELESS]: ({ wireless }) => {
-        const { ap_scan, network } = wireless;
-        const { essid, mode } = network;
-        const authMode = wirelessAuthModeFor(network);
+        const { ap_scan, network, networks } = wireless;
+
+        if (!network && !networks) return { wireless: { ap_scan } };
+
+        const first_network = network || networks[0];
+        const { essid, mode } = first_network;
+        const authMode = wirelessAuthModeFor(first_network);
 
         return {
             wireless: {
                 ap_scan, essid, mode: wirelessModeFor(mode), authMode,
                 // FIXME: we should use and object instead of destructuring the props
-                ...propsByAuthMode(authMode, network)
+                ...propsByAuthMode(authMode, first_network)
             }
         };
     }

--- a/src/lib/wicked/connections.test.js
+++ b/src/lib/wicked/connections.test.js
@@ -104,4 +104,91 @@ describe('#createConnection', () => {
             });
         });
     });
+
+    describe('when it is a wireless device', () => {
+        describe('and no wireless network is defined', () => {
+            const wickedConfig = {
+                name: 'wlan0',
+                wireless: {
+                    ap_scan: '1',
+                }
+            };
+
+            it('returns only common wireless configuration', () => {
+                const conn = createConnection(wickedConfig);
+                expect(conn.wireless).toEqual({
+                    ap_scan: '1'
+                });
+            });
+        });
+
+        describe('and one wireless network is defined', () => {
+            const wickedConfig = {
+                name: 'wlan0',
+                wireless: {
+                    ap_scan: '1',
+                    network: {
+                        essid: 'YaST-AP_1',
+                        scan_ssid: true,
+                        mode: 'infrastructure',
+                        key_management: 'WPA-PSK',
+                        wpa_psk: {
+                            passphrase: 'yast.password.test'
+                        }
+                    }
+                }
+            };
+
+            it('sets the wireless network configuration', () => {
+                const conn = createConnection(wickedConfig);
+                expect(conn.wireless).toEqual({
+                    ap_scan: '1',
+                    authMode: 'psk',
+                    essid: 'YaST-AP_1',
+                    mode: 'managed',
+                    password: 'yast.password.test'
+                });
+            });
+        });
+
+        describe('and multiple wireless network are defined', () => {
+            const wickedConfig = {
+                name: 'wlan0',
+                wireless: {
+                    ap_scan: '1',
+                    networks: [
+                        {
+                            essid: 'YaST-AP_1',
+                            scan_ssid: true,
+                            mode: 'infrastructure',
+                            key_management: 'WPA-PSK',
+                            wpa_psk: {
+                                passphrase: 'yast.password.test'
+                            }
+                        },
+                        {
+                            essid: 'YaST-AP_2',
+                            scan_ssid: true,
+                            mode: 'infrastructure',
+                            key_management: 'WPA-PSK',
+                            wpa_psk: {
+                                passphrase: 'yast.password.test'
+                            }
+                        }
+                    ]
+                }
+            };
+
+            it('sets the wireless network configuration', () => {
+                const conn = createConnection(wickedConfig);
+                expect(conn.wireless).toEqual({
+                    ap_scan: '1',
+                    authMode: 'psk',
+                    essid: 'YaST-AP_1',
+                    mode: 'managed',
+                    password: 'yast.password.test'
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
## Problem

The **cockpit-wicked** wireless configuration does not support multiple networks configurations and expect just one **network** section under **wireless**.

- https://bugzilla.suse.com/show_bug.cgi?id=1196528

## Solution

Adapt the configuration reader for supporting multiple network configuration and also previous XML schema but only read the first one defined as the UI must be adapted to expose and modify all of them.

## Tests

Extended wicked connections unit tests for covering wireless configuration and tested manually.

![WickedConnections](https://user-images.githubusercontent.com/7056681/160840999-380091cb-ef19-40af-9839-a09ffef47868.png)

