### PR TITLE
Add Conflicts cockpit-networkmanager

### DIFF
--- a/cockpit-wicked.spec.in
+++ b/cockpit-wicked.spec.in
@@ -32,6 +32,8 @@ Requires:       wicked
 BuildRequires:  nodejs-devel
 BuildRequires:  npm
 
+Conflicts:      cockpit-networkmanager
+
 %description
 Cockpit component for managing network configuration through Wicked
 


### PR DESCRIPTION
As cockpit-wicked uses the same URL path as cockpit-networkmanager they should not be installed together.