### PR TITLE
Updated minimum cockpit-devel version

### DIFF
--- a/packaging/cockpit-wicked.spec.in
+++ b/packaging/cockpit-wicked.spec.in
@@ -30,7 +30,7 @@ Source12:       node_modules.sums
 BuildArch:      noarch
 BuildRequires:  appstream-glib
 BuildRequires:  appstream-glib
-BuildRequires:  cockpit-devel >= 251
+BuildRequires:  cockpit-devel >= 293
 BuildRequires:  local-npm-registry
 BuildRequires:  make
 BuildRequires:  nodejs-devel


### PR DESCRIPTION
The old minimum version 251 doesn't include the required files to build the updated cockpit-wicked.

I missed this detail when doing https://github.com/openSUSE/cockpit-wicked/pull/139